### PR TITLE
licenseRepository added as configuration parameter 

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ By default, all files are placed in *${project.build.directory}/generated-resour
         <licensesOutputDirectory>${license.output.directory}</licensesOutputDirectory>
         <outputDirectory>${license.output.directory}</outputDirectory>
         <skip>${license.skip}</skip>
+        <licenseRepository>${license.repo.git.url}</licenseRepository>
     </configuration>
     <executions>
         <execution>
@@ -67,8 +68,6 @@ By default, all files are placed in *${project.build.directory}/generated-resour
 ```
         
 * Add generated license files into distribution (applied only for explicitly distributed components)
-* The parameter **license-registry.git-repository** is mandatory parameter specifies the URL of the license repository. 
-It can be provided as either an environment variable or as JVM argument, for example ```mvn clean install -Dlicense-registry.git-repository=<repository_url>```
 
 * Example for assembling with maven-war-plugin: 
 ```xml

--- a/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
@@ -258,10 +258,10 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.1
      */
-    @Parameter(property = "license.includedLicenses")
+    @Parameter( property = "license.includedLicenses")
     IncludedLicenses includedLicenses;
 
-    @Parameter(property = "license.hiddenLicenses")
+    @Parameter( property = "license.hiddenLicenses")
     HiddenLicenses hiddenLicenses;
 
     Map<String, List<Dependency>> includedDependencies = new HashMap<>();
@@ -290,7 +290,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.1
      */
-    @Parameter(property = "license.excludedLicenses")
+    @Parameter( property = "license.excludedLicenses")
     ExcludedLicenses excludedLicenses;
 
     /**
@@ -301,7 +301,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.0
      */
-    @Parameter(property = "license.bundleThirdPartyPath",
+    @Parameter( property = "license.bundleThirdPartyPath",
             defaultValue = "META-INF/${project.artifactId}-THIRD-PARTY.txt" )
     String bundleThirdPartyPath;
 
@@ -313,7 +313,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.0
      */
-    @Parameter(property = "license.generateBundle", defaultValue = "false" )
+    @Parameter( property = "license.generateBundle", defaultValue = "false" )
     boolean generateBundle;
 
     /**
@@ -321,7 +321,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.0
      */
-    @Parameter(property = "license.force", defaultValue = "false" )
+    @Parameter( property = "license.force", defaultValue = "false" )
     boolean force;
 
     /**
@@ -331,7 +331,7 @@ public abstract class AbstractAddThirdPartyMojo
      * @deprecated since 1.14, use now {@link #failOnMissing} or {@link #failOnBlacklist}.
      */
     @Deprecated
-    @Parameter(property = "license.failIfWarning", defaultValue = "false" )
+    @Parameter( property = "license.failIfWarning", defaultValue = "false" )
     boolean failIfWarning;
 
     /**
@@ -339,7 +339,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.14
      */
-    @Parameter(property = "license.failOnMissing", defaultValue = "false" )
+    @Parameter( property = "license.failOnMissing", defaultValue = "false" )
     boolean failOnMissing;
 
     /**
@@ -347,7 +347,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.14
      */
-    @Parameter(property = "license.failOnBlacklist", defaultValue = "false" )
+    @Parameter( property = "license.failOnBlacklist", defaultValue = "false" )
     boolean failOnBlacklist;
 
     @Parameter(property = "license.failOnNotWhitelistedDependency", defaultValue = "false")
@@ -360,7 +360,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.6
      */
-    @Parameter(property = "license.sortArtifactByName", defaultValue = "false" )
+    @Parameter( property = "license.sortArtifactByName", defaultValue = "false" )
     boolean sortArtifactByName;
 
     @Parameter(property = "license.includedDependenciesWhitelist")
@@ -378,7 +378,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.1
      */
-    @Parameter(property = "license.fileTemplate", defaultValue = "/org/codehaus/mojo/license/third-party-file.ftl" )
+    @Parameter( property = "license.fileTemplate", defaultValue = "/org/codehaus/mojo/license/third-party-file.ftl" )
     String fileTemplate;
 
     /**
@@ -386,7 +386,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.0.0
      */
-    @Parameter(property = "localRepository", required = true, readonly = true )
+    @Parameter( property = "localRepository", required = true, readonly = true )
     ArtifactRepository localRepository;
 
     /**
@@ -394,13 +394,13 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.0.0
      */
-    @Parameter(property = "project.remoteArtifactRepositories", required = true, readonly = true )
+    @Parameter( property = "project.remoteArtifactRepositories", required = true, readonly = true )
     List<ArtifactRepository> remoteRepositories;
 
     /**
      * The set of dependencies for the current project, used to locate license databases.
      */
-    @Parameter(property = "project.artifacts", required = true, readonly = true )
+    @Parameter( property = "project.artifacts", required = true, readonly = true )
     Set<Artifact> dependencies;
 
     // ----------------------------------------------------------------------

--- a/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
@@ -71,7 +71,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.0
      */
-    @Parameter( property = "license.outputDirectory",
+    @Parameter(property = "license.outputDirectory",
             defaultValue = "${project.build.directory}/generated-resources/licenses", required = true )
     private File outputDirectory;
 
@@ -80,7 +80,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.0
      */
-    @Parameter( property = "license.deployMissingFile", defaultValue = "true" )
+    @Parameter(property = "license.deployMissingFile", defaultValue = "true" )
     boolean deployMissingFile;
 
     /**
@@ -91,7 +91,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.0
      */
-    @Parameter( property = "license.useRepositoryMissingFiles", defaultValue = "true" )
+    @Parameter(property = "license.useRepositoryMissingFiles", defaultValue = "true" )
     boolean useRepositoryMissingFiles;
 
     /**
@@ -101,7 +101,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.1
      */
-    @Parameter( property = "license.acceptPomPackaging", defaultValue = "false" )
+    @Parameter(property = "license.acceptPomPackaging", defaultValue = "false" )
     boolean acceptPomPackaging;
 
     /**
@@ -109,7 +109,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.1
      */
-    @Parameter( property = "license.excludedScopes", defaultValue = "system" )
+    @Parameter(property = "license.excludedScopes", defaultValue = "system" )
     String excludedScopes;
 
     /**
@@ -117,7 +117,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.1
      */
-    @Parameter( property = "license.includedScopes")
+    @Parameter(property = "license.includedScopes")
     String includedScopes;
 
     /**
@@ -126,7 +126,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.1
      */
-    @Parameter( property = "license.excludedGroups")
+    @Parameter(property = "license.excludedGroups")
     String excludedGroups;
 
     /**
@@ -135,7 +135,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.1
      */
-    @Parameter( property = "license.includedGroups")
+    @Parameter(property = "license.includedGroups")
     String includedGroups;
 
     /**
@@ -144,7 +144,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.1
      */
-    @Parameter( property = "license.excludedArtifacts")
+    @Parameter(property = "license.excludedArtifacts")
     String excludedArtifacts;
 
     /**
@@ -153,7 +153,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.1
      */
-    @Parameter( property = "license.includedArtifacts")
+    @Parameter(property = "license.includedArtifacts")
     String includedArtifacts;
 
     /**
@@ -162,7 +162,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.1
      */
-    @Parameter( property = "license.includeTransitiveDependencies", defaultValue = "true" )
+    @Parameter(property = "license.includeTransitiveDependencies", defaultValue = "true" )
     boolean includeTransitiveDependencies;
 
     /**
@@ -170,7 +170,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.13
      */
-    @Parameter( property = "license.excludeTransitiveDependencies", defaultValue = "false" )
+    @Parameter(property = "license.excludeTransitiveDependencies", defaultValue = "false" )
     boolean excludeTransitiveDependencies;
 
     /**
@@ -178,10 +178,10 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.0
      */
-    @Parameter( property = "license.thirdPartyFilename", defaultValue = "THIRD-PARTY.txt", required = true )
+    @Parameter(property = "license.thirdPartyFilename", defaultValue = "THIRD-PARTY.txt", required = true )
     String thirdPartyFilename;
 
-    @Parameter( property = "license.thirdPartyDepsFilename", defaultValue = "THIRD-PARTY-DEPS", required = true )
+    @Parameter(property = "license.thirdPartyDepsFilename", defaultValue = "THIRD-PARTY-DEPS", required = true )
     String thirdPartyDepsJsonFilename;
 
     /**
@@ -189,7 +189,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.0
      */
-    @Parameter( property = "license.useMissingFile", defaultValue = "false" )
+    @Parameter(property = "license.useMissingFile", defaultValue = "false" )
     boolean useMissingFile;
 
     /**
@@ -197,7 +197,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.0
      */
-    @Parameter( property = "license.missingFile", defaultValue = "src/license/THIRD-PARTY.properties" )
+    @Parameter(property = "license.missingFile", defaultValue = "src/license/THIRD-PARTY.properties" )
     File missingFile;
 
     /**
@@ -205,7 +205,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.14
      */
-    @Parameter( property = "license.missingLicensesFileArtifact" )
+    @Parameter(property = "license.missingLicensesFileArtifact" )
     String missingLicensesFileArtifact;
 
     /**
@@ -213,7 +213,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.12
      */
-    @Parameter( property = "license.overrideFile", defaultValue = "src/license/override-THIRD-PARTY.properties" )
+    @Parameter(property = "license.overrideFile", defaultValue = "src/license/override-THIRD-PARTY.properties" )
     File overrideFile;
 
 
@@ -258,10 +258,10 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.1
      */
-    @Parameter( property = "license.includedLicenses")
+    @Parameter(property = "license.includedLicenses")
     IncludedLicenses includedLicenses;
 
-    @Parameter( property = "license.hiddenLicenses")
+    @Parameter(property = "license.hiddenLicenses")
     HiddenLicenses hiddenLicenses;
 
     Map<String, List<Dependency>> includedDependencies = new HashMap<>();
@@ -290,7 +290,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.1
      */
-    @Parameter( property = "license.excludedLicenses")
+    @Parameter(property = "license.excludedLicenses")
     ExcludedLicenses excludedLicenses;
 
     /**
@@ -301,7 +301,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.0
      */
-    @Parameter( property = "license.bundleThirdPartyPath",
+    @Parameter(property = "license.bundleThirdPartyPath",
             defaultValue = "META-INF/${project.artifactId}-THIRD-PARTY.txt" )
     String bundleThirdPartyPath;
 
@@ -313,7 +313,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.0
      */
-    @Parameter( property = "license.generateBundle", defaultValue = "false" )
+    @Parameter(property = "license.generateBundle", defaultValue = "false" )
     boolean generateBundle;
 
     /**
@@ -321,7 +321,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.0
      */
-    @Parameter( property = "license.force", defaultValue = "false" )
+    @Parameter(property = "license.force", defaultValue = "false" )
     boolean force;
 
     /**
@@ -331,7 +331,7 @@ public abstract class AbstractAddThirdPartyMojo
      * @deprecated since 1.14, use now {@link #failOnMissing} or {@link #failOnBlacklist}.
      */
     @Deprecated
-    @Parameter( property = "license.failIfWarning", defaultValue = "false" )
+    @Parameter(property = "license.failIfWarning", defaultValue = "false" )
     boolean failIfWarning;
 
     /**
@@ -339,7 +339,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.14
      */
-    @Parameter( property = "license.failOnMissing", defaultValue = "false" )
+    @Parameter(property = "license.failOnMissing", defaultValue = "false" )
     boolean failOnMissing;
 
     /**
@@ -347,7 +347,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.14
      */
-    @Parameter( property = "license.failOnBlacklist", defaultValue = "false" )
+    @Parameter(property = "license.failOnBlacklist", defaultValue = "false" )
     boolean failOnBlacklist;
 
     @Parameter(property = "license.failOnNotWhitelistedDependency", defaultValue = "false")
@@ -360,7 +360,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.6
      */
-    @Parameter( property = "license.sortArtifactByName", defaultValue = "false" )
+    @Parameter(property = "license.sortArtifactByName", defaultValue = "false" )
     boolean sortArtifactByName;
 
     @Parameter(property = "license.includedDependenciesWhitelist")
@@ -378,7 +378,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.1
      */
-    @Parameter( property = "license.fileTemplate", defaultValue = "/org/codehaus/mojo/license/third-party-file.ftl" )
+    @Parameter(property = "license.fileTemplate", defaultValue = "/org/codehaus/mojo/license/third-party-file.ftl" )
     String fileTemplate;
 
     /**
@@ -386,7 +386,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.0.0
      */
-    @Parameter( property = "localRepository", required = true, readonly = true )
+    @Parameter(property = "localRepository", required = true, readonly = true )
     ArtifactRepository localRepository;
 
     /**
@@ -394,13 +394,13 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.0.0
      */
-    @Parameter( property = "project.remoteArtifactRepositories", required = true, readonly = true )
+    @Parameter(property = "project.remoteArtifactRepositories", required = true, readonly = true )
     List<ArtifactRepository> remoteRepositories;
 
     /**
      * The set of dependencies for the current project, used to locate license databases.
      */
-    @Parameter( property = "project.artifacts", required = true, readonly = true )
+    @Parameter(property = "project.artifacts", required = true, readonly = true )
     Set<Artifact> dependencies;
 
     // ----------------------------------------------------------------------
@@ -507,7 +507,7 @@ public abstract class AbstractAddThirdPartyMojo
         }
 
         getLog().info("Loading WHITE licenses: licenses-whitelist.txt");
-        final LicenseRegistryClient licenseRegistryClient = LicenseRegistryClient.getInstance();
+        final LicenseRegistryClient licenseRegistryClient = LicenseRegistryClient.getInstance(licenseRepository);
         this.includedLicenses = new IncludedLicenses(licenseRegistryClient.getFileContent("licenses-whitelist.txt"));
         getLog().info("Loading HIDDEN licenses: licenses-hidden.txt");
         this.hiddenLicenses = new HiddenLicenses(licenseRegistryClient.getFileContent("licenses-hidden.txt"));
@@ -575,7 +575,7 @@ public abstract class AbstractAddThirdPartyMojo
             licenseMerges = new ArrayList<>();
         }
 
-        getHelper().mergeLicenses( licenseMerges, licenseMap);
+        getHelper().mergeLicenses( licenseMerges, licenseMap, licenseRepository);
 
         if ( checkUnsafeDependencies() )
         {
@@ -984,7 +984,7 @@ public abstract class AbstractAddThirdPartyMojo
             {
                 licenseMap1 = licenseMap.toLicenseMapOrderByName();
             }
-            thirdPartyTool.writeThirdPartyFile( licenseMap1, thirdPartyFile, isVerbose(), getEncoding(), "templates/third-party-file.ftl", true );
+            thirdPartyTool.writeThirdPartyFile( licenseMap1, thirdPartyFile, isVerbose(), getEncoding(), "templates/third-party-file.ftl", true, licenseRepository );
         }
 
         if ( doGenerateBundle )
@@ -1001,7 +1001,7 @@ public abstract class AbstractAddThirdPartyMojo
     }
 
     void overrideLicenses() throws IOException {
-        thirdPartyTool.overrideLicenses( licenseMap, projectDependencies, getEncoding(), "thirdparty-licenses.properties");
+        thirdPartyTool.overrideLicenses( licenseMap, projectDependencies, getEncoding(), "thirdparty-licenses.properties", licenseRepository);
     }
 
     private boolean isFailOnMissing() {

--- a/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
@@ -71,7 +71,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.0
      */
-    @Parameter(property = "license.outputDirectory",
+    @Parameter( property = "license.outputDirectory",
             defaultValue = "${project.build.directory}/generated-resources/licenses", required = true )
     private File outputDirectory;
 
@@ -80,7 +80,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.0
      */
-    @Parameter(property = "license.deployMissingFile", defaultValue = "true" )
+    @Parameter( property = "license.deployMissingFile", defaultValue = "true" )
     boolean deployMissingFile;
 
     /**
@@ -91,7 +91,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.0
      */
-    @Parameter(property = "license.useRepositoryMissingFiles", defaultValue = "true" )
+    @Parameter( property = "license.useRepositoryMissingFiles", defaultValue = "true" )
     boolean useRepositoryMissingFiles;
 
     /**
@@ -101,7 +101,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.1
      */
-    @Parameter(property = "license.acceptPomPackaging", defaultValue = "false" )
+    @Parameter( property = "license.acceptPomPackaging", defaultValue = "false" )
     boolean acceptPomPackaging;
 
     /**
@@ -109,7 +109,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.1
      */
-    @Parameter(property = "license.excludedScopes", defaultValue = "system" )
+    @Parameter( property = "license.excludedScopes", defaultValue = "system" )
     String excludedScopes;
 
     /**
@@ -117,7 +117,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.1
      */
-    @Parameter(property = "license.includedScopes")
+    @Parameter( property = "license.includedScopes")
     String includedScopes;
 
     /**
@@ -126,7 +126,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.1
      */
-    @Parameter(property = "license.excludedGroups")
+    @Parameter( property = "license.excludedGroups")
     String excludedGroups;
 
     /**
@@ -135,7 +135,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.1
      */
-    @Parameter(property = "license.includedGroups")
+    @Parameter( property = "license.includedGroups")
     String includedGroups;
 
     /**
@@ -144,7 +144,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.1
      */
-    @Parameter(property = "license.excludedArtifacts")
+    @Parameter( property = "license.excludedArtifacts")
     String excludedArtifacts;
 
     /**
@@ -153,7 +153,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.1
      */
-    @Parameter(property = "license.includedArtifacts")
+    @Parameter( property = "license.includedArtifacts")
     String includedArtifacts;
 
     /**
@@ -162,7 +162,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.1
      */
-    @Parameter(property = "license.includeTransitiveDependencies", defaultValue = "true" )
+    @Parameter( property = "license.includeTransitiveDependencies", defaultValue = "true" )
     boolean includeTransitiveDependencies;
 
     /**
@@ -170,7 +170,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.13
      */
-    @Parameter(property = "license.excludeTransitiveDependencies", defaultValue = "false" )
+    @Parameter( property = "license.excludeTransitiveDependencies", defaultValue = "false" )
     boolean excludeTransitiveDependencies;
 
     /**
@@ -178,10 +178,10 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.0
      */
-    @Parameter(property = "license.thirdPartyFilename", defaultValue = "THIRD-PARTY.txt", required = true )
+    @Parameter( property = "license.thirdPartyFilename", defaultValue = "THIRD-PARTY.txt", required = true )
     String thirdPartyFilename;
 
-    @Parameter(property = "license.thirdPartyDepsFilename", defaultValue = "THIRD-PARTY-DEPS", required = true )
+    @Parameter( property = "license.thirdPartyDepsFilename", defaultValue = "THIRD-PARTY-DEPS", required = true )
     String thirdPartyDepsJsonFilename;
 
     /**
@@ -189,7 +189,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.0
      */
-    @Parameter(property = "license.useMissingFile", defaultValue = "false" )
+    @Parameter( property = "license.useMissingFile", defaultValue = "false" )
     boolean useMissingFile;
 
     /**
@@ -197,7 +197,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.0
      */
-    @Parameter(property = "license.missingFile", defaultValue = "src/license/THIRD-PARTY.properties" )
+    @Parameter( property = "license.missingFile", defaultValue = "src/license/THIRD-PARTY.properties" )
     File missingFile;
 
     /**
@@ -205,7 +205,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.14
      */
-    @Parameter(property = "license.missingLicensesFileArtifact" )
+    @Parameter( property = "license.missingLicensesFileArtifact" )
     String missingLicensesFileArtifact;
 
     /**
@@ -213,7 +213,7 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.12
      */
-    @Parameter(property = "license.overrideFile", defaultValue = "src/license/override-THIRD-PARTY.properties" )
+    @Parameter( property = "license.overrideFile", defaultValue = "src/license/override-THIRD-PARTY.properties" )
     File overrideFile;
 
 

--- a/src/main/java/org/codehaus/mojo/license/AbstractDownloadLicensesMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractDownloadLicensesMojo.java
@@ -45,7 +45,7 @@ public abstract class AbstractDownloadLicensesMojo
      *
      * @since 1.14
      */
-    @Parameter(property = "license.failOnMissing", defaultValue = "false" )
+    @Parameter( property = "license.failOnMissing", defaultValue = "false" )
     boolean failOnMissing;
 
     /**
@@ -53,7 +53,7 @@ public abstract class AbstractDownloadLicensesMojo
      *
      * @since 1.14
      */
-    @Parameter(property = "license.failOnBlacklist", defaultValue = "false" )
+    @Parameter( property = "license.failOnBlacklist", defaultValue = "false" )
     boolean failOnBlacklist;
 
 

--- a/src/main/java/org/codehaus/mojo/license/AbstractDownloadLicensesMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractDownloadLicensesMojo.java
@@ -248,17 +248,6 @@ public abstract class AbstractDownloadLicensesMojo
      */
     private String proxyLoginPasswordEncoded;
 
-    /**
-     * Encoding used to read and writes files.
-     * <p>
-     * <b>Note:</b> If nothing is filled here, we will use the system
-     * property {@code file.encoding}.
-     *
-     * @since 1.0
-     */
-    @Parameter(property = "license.encoding", defaultValue = "${project.build.sourceEncoding}")
-    String encoding;
-
     protected abstract SortedMap<String, MavenProject> getDependencies();
 
     // ----------------------------------------------------------------------

--- a/src/main/java/org/codehaus/mojo/license/AbstractFileHeaderMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractFileHeaderMojo.java
@@ -71,7 +71,7 @@ public abstract class AbstractFileHeaderMojo extends AbstractLicenseNameMojo
      *
      * @since 1.1
      */
-    @Parameter(property = "license.processStartTag" )
+    @Parameter( property = "license.processStartTag" )
     private String processStartTag;
 
     /**
@@ -81,7 +81,7 @@ public abstract class AbstractFileHeaderMojo extends AbstractLicenseNameMojo
      *
      * @since 1.1
      */
-    @Parameter(property = "license.processEndTag" )
+    @Parameter( property = "license.processEndTag" )
     private String processEndTag;
 
     /**
@@ -91,7 +91,7 @@ public abstract class AbstractFileHeaderMojo extends AbstractLicenseNameMojo
      *
      * @since 1.1
      */
-    @Parameter(property = "license.sectionDelimiter" )
+    @Parameter( property = "license.sectionDelimiter" )
     private String sectionDelimiter;
 
     /**
@@ -105,7 +105,7 @@ public abstract class AbstractFileHeaderMojo extends AbstractLicenseNameMojo
      *
      * @since 1.0
      */
-    @Parameter(property = "license.addSvnKeyWords", defaultValue = "false" )
+    @Parameter( property = "license.addSvnKeyWords", defaultValue = "false" )
     private boolean addSvnKeyWords;
 
     /**
@@ -116,7 +116,7 @@ public abstract class AbstractFileHeaderMojo extends AbstractLicenseNameMojo
      *
      * @since 1.0
      */
-    @Parameter(property = "license.canUpdateDescription", defaultValue = "false" )
+    @Parameter( property = "license.canUpdateDescription", defaultValue = "false" )
     private boolean canUpdateDescription;
 
     /**
@@ -127,7 +127,7 @@ public abstract class AbstractFileHeaderMojo extends AbstractLicenseNameMojo
      *
      * @since 1.0
      */
-    @Parameter(property = "license.canUpdateCopyright", defaultValue = "false" )
+    @Parameter( property = "license.canUpdateCopyright", defaultValue = "false" )
     private boolean canUpdateCopyright;
 
     /**
@@ -138,7 +138,7 @@ public abstract class AbstractFileHeaderMojo extends AbstractLicenseNameMojo
      *
      * @since 1.0
      */
-    @Parameter(property = "license.canUpdateLicense", defaultValue = "true" )
+    @Parameter( property = "license.canUpdateLicense", defaultValue = "true" )
     private boolean canUpdateLicense;
 
     /**
@@ -150,7 +150,7 @@ public abstract class AbstractFileHeaderMojo extends AbstractLicenseNameMojo
      *
      * @since 1.0
      */
-    @Parameter(property = "license.ignoreTag" )
+    @Parameter( property = "license.ignoreTag" )
     String ignoreTag;
 
     /**
@@ -162,7 +162,7 @@ public abstract class AbstractFileHeaderMojo extends AbstractLicenseNameMojo
      *
      * @since 1.2
      */
-    @Parameter(property = "license.addJavaLicenseAfterPackage", defaultValue = "true" )
+    @Parameter( property = "license.addJavaLicenseAfterPackage", defaultValue = "true" )
     private boolean addJavaLicenseAfterPackage;
 
     /**
@@ -172,7 +172,7 @@ public abstract class AbstractFileHeaderMojo extends AbstractLicenseNameMojo
      *
      * @since 1.9
      */
-    @Parameter(property = "license.useJavaNoReformatCommentStartTag", defaultValue = "true" )
+    @Parameter( property = "license.useJavaNoReformatCommentStartTag", defaultValue = "true" )
     private boolean useJavaNoReformatCommentStartTag;
 
     /**
@@ -185,7 +185,7 @@ public abstract class AbstractFileHeaderMojo extends AbstractLicenseNameMojo
      *
      * @since 1.9
      */
-    @Parameter(property = "license.emptyLineAfterHeader", defaultValue = "false" )
+    @Parameter( property = "license.emptyLineAfterHeader", defaultValue = "false" )
     private boolean emptyLineAfterHeader;
 
     /**
@@ -198,7 +198,7 @@ public abstract class AbstractFileHeaderMojo extends AbstractLicenseNameMojo
      *
      * @since 1.9
      */
-    @Parameter(property = "license.ignoreNoFileToScan", defaultValue = "false" )
+    @Parameter( property = "license.ignoreNoFileToScan", defaultValue = "false" )
     private boolean ignoreNoFileToScan;
 
     /**
@@ -215,7 +215,7 @@ public abstract class AbstractFileHeaderMojo extends AbstractLicenseNameMojo
      *
      * @since 1.0
      */
-    @Parameter(property = "license.roots" )
+    @Parameter( property = "license.roots" )
     private String[] roots;
 
     /**
@@ -225,7 +225,7 @@ public abstract class AbstractFileHeaderMojo extends AbstractLicenseNameMojo
      *
      * @since 1.0
      */
-    @Parameter(property = "license.includes" )
+    @Parameter( property = "license.includes" )
     private String[] includes;
 
     /**
@@ -238,7 +238,7 @@ public abstract class AbstractFileHeaderMojo extends AbstractLicenseNameMojo
      *
      * @since 1.0
      */
-    @Parameter(property = "license.excludes" )
+    @Parameter( property = "license.excludes" )
     private String[] excludes;
 
     /**
@@ -288,7 +288,7 @@ public abstract class AbstractFileHeaderMojo extends AbstractLicenseNameMojo
      *
      * @since 1.1
      */
-    @Parameter(property = "license.descriptionTemplate",
+    @Parameter( property = "license.descriptionTemplate",
             defaultValue = "/org/codehaus/mojo/license/default-file-header-description.ftl" )
     private String descriptionTemplate;
 

--- a/src/main/java/org/codehaus/mojo/license/AbstractFileHeaderMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractFileHeaderMojo.java
@@ -71,7 +71,7 @@ public abstract class AbstractFileHeaderMojo extends AbstractLicenseNameMojo
      *
      * @since 1.1
      */
-    @Parameter( property = "license.processStartTag" )
+    @Parameter(property = "license.processStartTag" )
     private String processStartTag;
 
     /**
@@ -81,7 +81,7 @@ public abstract class AbstractFileHeaderMojo extends AbstractLicenseNameMojo
      *
      * @since 1.1
      */
-    @Parameter( property = "license.processEndTag" )
+    @Parameter(property = "license.processEndTag" )
     private String processEndTag;
 
     /**
@@ -91,7 +91,7 @@ public abstract class AbstractFileHeaderMojo extends AbstractLicenseNameMojo
      *
      * @since 1.1
      */
-    @Parameter( property = "license.sectionDelimiter" )
+    @Parameter(property = "license.sectionDelimiter" )
     private String sectionDelimiter;
 
     /**
@@ -105,7 +105,7 @@ public abstract class AbstractFileHeaderMojo extends AbstractLicenseNameMojo
      *
      * @since 1.0
      */
-    @Parameter( property = "license.addSvnKeyWords", defaultValue = "false" )
+    @Parameter(property = "license.addSvnKeyWords", defaultValue = "false" )
     private boolean addSvnKeyWords;
 
     /**
@@ -116,7 +116,7 @@ public abstract class AbstractFileHeaderMojo extends AbstractLicenseNameMojo
      *
      * @since 1.0
      */
-    @Parameter( property = "license.canUpdateDescription", defaultValue = "false" )
+    @Parameter(property = "license.canUpdateDescription", defaultValue = "false" )
     private boolean canUpdateDescription;
 
     /**
@@ -127,7 +127,7 @@ public abstract class AbstractFileHeaderMojo extends AbstractLicenseNameMojo
      *
      * @since 1.0
      */
-    @Parameter( property = "license.canUpdateCopyright", defaultValue = "false" )
+    @Parameter(property = "license.canUpdateCopyright", defaultValue = "false" )
     private boolean canUpdateCopyright;
 
     /**
@@ -138,7 +138,7 @@ public abstract class AbstractFileHeaderMojo extends AbstractLicenseNameMojo
      *
      * @since 1.0
      */
-    @Parameter( property = "license.canUpdateLicense", defaultValue = "true" )
+    @Parameter(property = "license.canUpdateLicense", defaultValue = "true" )
     private boolean canUpdateLicense;
 
     /**
@@ -150,7 +150,7 @@ public abstract class AbstractFileHeaderMojo extends AbstractLicenseNameMojo
      *
      * @since 1.0
      */
-    @Parameter( property = "license.ignoreTag" )
+    @Parameter(property = "license.ignoreTag" )
     String ignoreTag;
 
     /**
@@ -162,7 +162,7 @@ public abstract class AbstractFileHeaderMojo extends AbstractLicenseNameMojo
      *
      * @since 1.2
      */
-    @Parameter( property = "license.addJavaLicenseAfterPackage", defaultValue = "true" )
+    @Parameter(property = "license.addJavaLicenseAfterPackage", defaultValue = "true" )
     private boolean addJavaLicenseAfterPackage;
 
     /**
@@ -172,7 +172,7 @@ public abstract class AbstractFileHeaderMojo extends AbstractLicenseNameMojo
      *
      * @since 1.9
      */
-    @Parameter( property = "license.useJavaNoReformatCommentStartTag", defaultValue = "true" )
+    @Parameter(property = "license.useJavaNoReformatCommentStartTag", defaultValue = "true" )
     private boolean useJavaNoReformatCommentStartTag;
 
     /**
@@ -185,7 +185,7 @@ public abstract class AbstractFileHeaderMojo extends AbstractLicenseNameMojo
      *
      * @since 1.9
      */
-    @Parameter( property = "license.emptyLineAfterHeader", defaultValue = "false" )
+    @Parameter(property = "license.emptyLineAfterHeader", defaultValue = "false" )
     private boolean emptyLineAfterHeader;
 
     /**
@@ -198,7 +198,7 @@ public abstract class AbstractFileHeaderMojo extends AbstractLicenseNameMojo
      *
      * @since 1.9
      */
-    @Parameter( property = "license.ignoreNoFileToScan", defaultValue = "false" )
+    @Parameter(property = "license.ignoreNoFileToScan", defaultValue = "false" )
     private boolean ignoreNoFileToScan;
 
     /**
@@ -215,7 +215,7 @@ public abstract class AbstractFileHeaderMojo extends AbstractLicenseNameMojo
      *
      * @since 1.0
      */
-    @Parameter( property = "license.roots" )
+    @Parameter(property = "license.roots" )
     private String[] roots;
 
     /**
@@ -225,7 +225,7 @@ public abstract class AbstractFileHeaderMojo extends AbstractLicenseNameMojo
      *
      * @since 1.0
      */
-    @Parameter( property = "license.includes" )
+    @Parameter(property = "license.includes" )
     private String[] includes;
 
     /**
@@ -238,7 +238,7 @@ public abstract class AbstractFileHeaderMojo extends AbstractLicenseNameMojo
      *
      * @since 1.0
      */
-    @Parameter( property = "license.excludes" )
+    @Parameter(property = "license.excludes" )
     private String[] excludes;
 
     /**
@@ -288,7 +288,7 @@ public abstract class AbstractFileHeaderMojo extends AbstractLicenseNameMojo
      *
      * @since 1.1
      */
-    @Parameter( property = "license.descriptionTemplate",
+    @Parameter(property = "license.descriptionTemplate",
             defaultValue = "/org/codehaus/mojo/license/default-file-header-description.ftl" )
     private String descriptionTemplate;
 

--- a/src/main/java/org/codehaus/mojo/license/AbstractLicenseMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractLicenseMojo.java
@@ -50,6 +50,9 @@ public abstract class AbstractLicenseMojo
     // ----------------------------------------------------------------------
 
     /**
+     * Sets whether to skip the execution of the goal.
+     * If set to true, the goal execution will be skipped.
+     *
      * @since 1.14.25
      */
     @Parameter(property = "license.skip", defaultValue = "false" )

--- a/src/main/java/org/codehaus/mojo/license/AbstractLicenseMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractLicenseMojo.java
@@ -64,7 +64,7 @@ public abstract class AbstractLicenseMojo
      *
      * @since 1.0
      */
-    @Parameter(property = "license.verbose", defaultValue = "${maven.verbose}" )
+    @Parameter( property = "license.verbose", defaultValue = "${maven.verbose}" )
     protected boolean verbose;
 
     /**
@@ -75,7 +75,7 @@ public abstract class AbstractLicenseMojo
      *
      * @since 1.0
      */
-    @Parameter(property = "license.encoding", defaultValue = "${project.build.sourceEncoding}" )
+    @Parameter( property = "license.encoding", defaultValue = "${project.build.sourceEncoding}" )
     protected String encoding;
 
     /**

--- a/src/main/java/org/codehaus/mojo/license/AbstractLicenseMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractLicenseMojo.java
@@ -53,7 +53,7 @@ public abstract class AbstractLicenseMojo
      * @since 1.14.25
      */
     @Parameter(property = "license.skip", defaultValue = "false" )
-    private boolean skip;
+    protected boolean skip;
 
 
     /**
@@ -64,8 +64,8 @@ public abstract class AbstractLicenseMojo
      *
      * @since 1.0
      */
-    @Parameter( property = "license.verbose", defaultValue = "${maven.verbose}" )
-    boolean verbose;
+    @Parameter(property = "license.verbose", defaultValue = "${maven.verbose}" )
+    protected boolean verbose;
 
     /**
      * Encoding used to read and writes files.
@@ -75,8 +75,8 @@ public abstract class AbstractLicenseMojo
      *
      * @since 1.0
      */
-    @Parameter( property = "license.encoding", defaultValue = "${project.build.sourceEncoding}" )
-    String encoding;
+    @Parameter(property = "license.encoding", defaultValue = "${project.build.sourceEncoding}" )
+    protected String encoding;
 
     /**
      * Current maven session. (used to launch certain mojo once by build).
@@ -84,7 +84,7 @@ public abstract class AbstractLicenseMojo
      * @since 1.0
      */
     @Parameter( defaultValue = "${session}", readonly = true )
-    MavenSession session;
+    protected MavenSession session;
 
     /**
      * The reacted project.
@@ -92,10 +92,13 @@ public abstract class AbstractLicenseMojo
      * @since 1.0
      */
     @Parameter( defaultValue = "${project}", readonly = true )
-    MavenProject project;
+    protected MavenProject project;
 
     @Parameter(property="license.proxy", readonly = true)
-    String proxyUrl;
+    protected String proxyUrl;
+
+    @Parameter(property="license.repository", readonly = true)
+    protected String licenseRepository;
 
     // ----------------------------------------------------------------------
     // Abstract methods
@@ -155,9 +158,7 @@ public abstract class AbstractLicenseMojo
     /**
      * {@inheritDoc}
      */
-    public final void execute()
-        throws MojoExecutionException, MojoFailureException
-    {
+    public  void execute() throws MojoExecutionException, MojoFailureException {
         try
         {
             if ( getLog().isDebugEnabled() )
@@ -277,7 +278,7 @@ public abstract class AbstractLicenseMojo
     /**
      * @return {@code true} if verbose flag is on, {@code false} otherwise
      */
-    public final boolean isVerbose()
+    public boolean isVerbose()
     {
         return verbose;
     }

--- a/src/main/java/org/codehaus/mojo/license/AbstractThirdPartyReportMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractThirdPartyReportMojo.java
@@ -227,13 +227,8 @@ public abstract class AbstractThirdPartyReportMojo extends AbstractMavenReport i
     @Parameter( property = "localRepository", required = true, readonly = true )
     private ArtifactRepository localRepository;
 
-    /**
-     * The Maven Project.
-     *
-     * @since 1.1
-     */
-    @Parameter( defaultValue = "${project}", readonly = true )
-    private MavenProject project;
+    @Parameter(property="license.repository", readonly = true)
+    String licenseRepository;
 
     // ----------------------------------------------------------------------
     // Plexus Components
@@ -502,12 +497,12 @@ public abstract class AbstractThirdPartyReportMojo extends AbstractMavenReport i
         }
 
         // LicenseMap is now complete, let's merge licenses if necessary
-        thirdPartyHelper.mergeLicenses( licenseMerges, licenseMap);
+        thirdPartyHelper.mergeLicenses( licenseMerges, licenseMap, licenseRepository );
 
         // Add override licenses
         thirdPartyTool.overrideLicenses( licenseMap, projectDependencies, encoding, overrideFile );
 
-        // let's build third party details for each dependencies
+        // let's build third party details for each dependency
         Collection<ThirdPartyDetails> details = new ArrayList<ThirdPartyDetails>();
 
         for ( Map.Entry<MavenProject, String[]> entry : licenseMap.toDependencyMap().entrySet() )

--- a/src/main/java/org/codehaus/mojo/license/AggregateDownloadLicensesMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AggregateDownloadLicensesMojo.java
@@ -60,9 +60,20 @@ public class AggregateDownloadLicensesMojo
     /**
      * {@inheritDoc}
      */
-    protected boolean isSkip()
+    @Override
+    public boolean isSkip()
     {
         return skipAggregateDownloadLicenses || ( executeOnlyOnRootModule && !getProject().isExecutionRoot() );
+    }
+
+    @Override
+    protected void init() throws Exception {
+        throw new RuntimeException("This method is not implemented and should not be invoked");
+    }
+
+    @Override
+    protected void doAction() throws Exception {
+        throw new RuntimeException("This method is not implemented and should not be invoked");
     }
 
     /**

--- a/src/main/java/org/codehaus/mojo/license/DownloadLicensesMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/DownloadLicensesMojo.java
@@ -64,9 +64,19 @@ public class DownloadLicensesMojo
     /**
      * {@inheritDoc}
      */
-    protected boolean isSkip()
+    public boolean isSkip()
     {
         return skipDownloadLicenses;
+    }
+
+    @Override
+    protected void init() throws Exception {
+        throw new RuntimeException("This method is not implemented and should not be invoked");
+    }
+
+    @Override
+    protected void doAction() throws Exception {
+        throw new RuntimeException("This method is not implemented and should not be invoked");
     }
 
     protected SortedMap<String, MavenProject>  getDependencies()

--- a/src/main/java/org/codehaus/mojo/license/JarsJsonListMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/JarsJsonListMojo.java
@@ -56,9 +56,7 @@ import java.util.zip.ZipFile;
  *
  */
 @Mojo( name = "jars-json-list", requiresProject = false, requiresDirectInvocation = false, defaultPhase = LifecyclePhase.GENERATE_RESOURCES )
-public class JarsJsonListMojo
-    extends AbstractMojo
-{
+public class JarsJsonListMojo extends AbstractLicenseMojo {
 
     private static final Pattern JAR_VERSION_PATTERN = Pattern.compile("-r?\\d");
     private static final Pattern POM_XML_ENTRY = Pattern.compile("^META-INF/maven/.+/pom\\.xml$");
@@ -201,6 +199,21 @@ public class JarsJsonListMojo
         jarCoordinates.put("version", version);
         jarCoordinates.put("packaging", "jar");
         return jarCoordinates;
+    }
+
+    @Override
+    protected void doAction() throws Exception {
+        throw new RuntimeException("This method is not implemented and should not be invoked");
+    }
+
+    @Override
+    public boolean isSkip() {
+        return false;
+    }
+
+    @Override
+    protected void init() throws Exception {
+        throw new RuntimeException("This method is not implemented and should not be invoked");
     }
 
     private static String getAttribute(Properties artifacts, String artifactId, String attribute, String defaultValue) {

--- a/src/main/java/org/codehaus/mojo/license/api/DefaultThirdPartyHelper.java
+++ b/src/main/java/org/codehaus/mojo/license/api/DefaultThirdPartyHelper.java
@@ -276,11 +276,11 @@ public class DefaultThirdPartyHelper
     /**
      * {@inheritDoc}
      */
-    public void mergeLicenses( List<String> licenseMerges, LicenseMap licenseMap )
+    public void mergeLicenses( List<String> licenseMerges, LicenseMap licenseMap, String licenseRepositoryUrl )
             throws MojoFailureException
     {
         log.info("Loading merges from merges.txt");
-        Scanner mergesLines = new Scanner(LicenseRegistryClient.getInstance().getFileContent("merges.txt")).useDelimiter("\\n");
+        Scanner mergesLines = new Scanner(LicenseRegistryClient.getInstance(licenseRepositoryUrl).getFileContent("merges.txt")).useDelimiter("\\n");
         while (mergesLines.hasNext()) {
             licenseMerges.add(mergesLines.next());
         }

--- a/src/main/java/org/codehaus/mojo/license/api/DefaultThirdPartyTool.java
+++ b/src/main/java/org/codehaus/mojo/license/api/DefaultThirdPartyTool.java
@@ -656,15 +656,16 @@ public class DefaultThirdPartyTool
     }
 
     @Override
-    public void overrideLicenses(LicenseMap licenseMap, SortedMap<String, MavenProject> artifactCache, String encoding, String customOverrideFile) {
+    public void overrideLicenses(LicenseMap licenseMap, SortedMap<String, MavenProject> artifactCache, String encoding, String customOverrideFile, String licenseRepository) {
         SortedProperties overrideMappings = new SortedProperties( encoding );
+
 
         // there is some unsafe dependencies
         getLogger().info( "Load overrides from " + customOverrideFile);
         getLogger().info("Artifact cache " + artifactCache);
         // load the missing file
         try {
-            overrideMappings.load(new StringReader(LicenseRegistryClient.getInstance().getFileContent(customOverrideFile)));
+            overrideMappings.load(new StringReader(LicenseRegistryClient.getInstance(licenseRepository).getFileContent(customOverrideFile)));
         } catch (final IOException ioException) {
             throw new IllegalStateException(ioException);
         }
@@ -703,7 +704,7 @@ public class DefaultThirdPartyTool
     /**
      * {@inheritDoc}
      */
-    public void writeThirdPartyFile( LicenseMap licenseMap, File thirdPartyFile, boolean verbose, String encoding, String lineFormat, boolean custom)
+    public void writeThirdPartyFile( LicenseMap licenseMap, File thirdPartyFile, boolean verbose, String encoding, String lineFormat, boolean custom, String licenseRepositoryUrl)
             throws IOException
     {
         Logger log = getLogger();
@@ -713,7 +714,7 @@ public class DefaultThirdPartyTool
         final String content;
         if (custom) {
             getLogger().info("Get template from " +  lineFormat);
-            freeMarkerHelper = FreeMarkerHelper.newHelperFromContent(LicenseRegistryClient.getInstance().getFileContent(lineFormat));
+            freeMarkerHelper = FreeMarkerHelper.newHelperFromContent(LicenseRegistryClient.getInstance(licenseRepositoryUrl).getFileContent(lineFormat));
             content = freeMarkerHelper.renderTemplate(TEMPLATE, properties);
         } else {
             content = freeMarkerHelper.renderTemplate(lineFormat, properties);

--- a/src/main/java/org/codehaus/mojo/license/api/ThirdPartyHelper.java
+++ b/src/main/java/org/codehaus/mojo/license/api/ThirdPartyHelper.java
@@ -157,6 +157,6 @@ public interface ThirdPartyHelper
      * @throws MojoFailureException if there is a bad license merge definition (says for example two license with
      *                              same name)
      */
-    void mergeLicenses( List<String> licenseMerges, LicenseMap licenseMap ) throws MojoFailureException;
+    void mergeLicenses( List<String> licenseMerges, LicenseMap licenseMap, String licenseRepositoryUrl ) throws MojoFailureException;
 
 }

--- a/src/main/java/org/codehaus/mojo/license/api/ThirdPartyTool.java
+++ b/src/main/java/org/codehaus/mojo/license/api/ThirdPartyTool.java
@@ -157,7 +157,7 @@ public interface ThirdPartyTool
     void overrideLicenses( LicenseMap licenseMap, SortedMap<String, MavenProject> artifactCache, String encoding, File overrideFile ) throws IOException;
 
 
-    void overrideLicenses(LicenseMap licenseMap, SortedMap<String, MavenProject> artifactCache, String encoding, String overrideFileUrl) throws IOException;
+    void overrideLicenses(LicenseMap licenseMap, SortedMap<String, MavenProject> artifactCache, String encoding, String overrideFileUrl, String licenseRepositoryUrl) throws IOException;
 
     /**
      * Add one or more licenses (name and url are {@code licenseNames}) to the given {@code licenseMap} for the given
@@ -210,7 +210,7 @@ public interface ThirdPartyTool
      * @throws IOException if any probem while writing file
      */
     void writeThirdPartyFile( LicenseMap licenseMap, File thirdPartyFile, boolean verbose, String encoding,
-                              String template, boolean custom)
+                              String template, boolean custom, String licenseRepositoryUrl)
             throws IOException;
 
     /**

--- a/src/main/java/org/codehaus/mojo/license/utils/LicenseDownloader.java
+++ b/src/main/java/org/codehaus/mojo/license/utils/LicenseDownloader.java
@@ -63,7 +63,7 @@ public class LicenseDownloader
         }
     }
 
-    public void downloadLicense( String licenseUrlString, String loginPassword, File outputFile )
+    public void downloadLicense( String licenseUrlString, String loginPassword, File outputFile, String licenseRepositoryUrl )
         throws IOException
     {
 //        download2(licenseUrlString, outputFile);
@@ -75,7 +75,7 @@ public class LicenseDownloader
 
         final InputStream licenseInputStream;
         if (!licenseUrlString.startsWith("http") ) {
-            licenseInputStream = new ByteArrayInputStream(LicenseRegistryClient.getInstance().getFileContent(licenseUrlString).getBytes(StandardCharsets.UTF_8));
+            licenseInputStream = new ByteArrayInputStream(LicenseRegistryClient.getInstance(licenseRepositoryUrl).getFileContent(licenseUrlString).getBytes(StandardCharsets.UTF_8));
         } else {
             URLConnection connection = newConnection( licenseUrlString, loginPassword );
 

--- a/src/main/java/org/codehaus/mojo/license/utils/LicenseRegistryClient.java
+++ b/src/main/java/org/codehaus/mojo/license/utils/LicenseRegistryClient.java
@@ -90,12 +90,15 @@ public final class LicenseRegistryClient {
         return result;
     }
 
-    public synchronized static LicenseRegistryClient getInstance() {
+    public synchronized static LicenseRegistryClient getInstance(String repoUrl) {
         if (INSTANCE == null) {
             final String licenseRegistryGitRepository = Optional.ofNullable(
-                    System.getProperty(LICENSE_REGISTRY_GIT_REPOSITORY_PROPERTY_NAME,
-                            System.getenv(LICENSE_REGISTRY_GIT_REPOSITORY_PROPERTY_NAME))
-            ).orElseThrow(() -> new IllegalArgumentException("Either Environment variable or JVM argument for set 'license-registry.git-repository' must be provided"));
+                            System.getProperty(LICENSE_REGISTRY_GIT_REPOSITORY_PROPERTY_NAME,
+                                    System.getenv(LICENSE_REGISTRY_GIT_REPOSITORY_PROPERTY_NAME))
+                    )
+                    .orElseGet(() -> Optional.ofNullable(repoUrl)
+                            .orElseThrow(() -> new IllegalArgumentException("Either license.repository parameter or environment variable or JVM argument for set '"
+                                    + LICENSE_REGISTRY_GIT_REPOSITORY_PROPERTY_NAME + "' must be provided")));
             INSTANCE = new LicenseRegistryClient(licenseRegistryGitRepository);
         }
         return INSTANCE;


### PR DESCRIPTION
The primary objective is to declare the _licenseRepositoryGitUrl_ as a regular configuration parameter. This will enable the provision of a default value in the plugin configuration. Additionally, the hierarchy of mojos has been refined and redundant parameters have been eliminated.

Current mojos hierarchy:  
![graphviz](https://github.com/octopusden/octopus-license-maven-plugin/assets/2427004/83ddb303-b0f8-4adb-90d8-dc9fa93bf74d)
