### PR TITLE
Xray Integration Improvement

### DIFF
--- a/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
@@ -409,14 +409,14 @@ public abstract class AbstractAddThirdPartyMojo
     /**
      * Artifactory repository URL for retrieving license information with Xray.
      */
-    @Parameter( property = "artifactRepositoryUrl" )
-    private String artifactRepositoryUrl;
+    @Parameter( property = "artifactoryUrl" )
+    private String artifactoryUrl;
 
     /**
      * Artifactory repository access token for retrieving license information with Xray.
      */
-    @Parameter( property = "artifactRepositoryAccessToken" )
-    private String artifactRepositoryAccessToken;
+    @Parameter( property = "artifactoryAccessToken" )
+    private String artifactoryAccessToken;
 
     /**
      * A flag indicating whether to retrieve license information from the Sonatype Processor.
@@ -742,8 +742,8 @@ public abstract class AbstractAddThirdPartyMojo
         {
             helper =
                     new DefaultThirdPartyHelper( getProject(), getEncoding(), isVerbose(), dependenciesTool, thirdPartyTool,
-                                                 localRepository, remoteRepositories, getLog(), artifactRepositoryUrl,
-                                                 artifactRepositoryAccessToken, isUseSonatypeProcessor, isUseXrayProcessor );
+                                                 localRepository, remoteRepositories, getLog(), artifactoryUrl,
+                                                 artifactoryAccessToken, isUseSonatypeProcessor, isUseXrayProcessor );
         }
         return helper;
     }

--- a/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
@@ -407,13 +407,13 @@ public abstract class AbstractAddThirdPartyMojo
     Set<Artifact> dependencies;
 
     /**
-     * Artifactory repository URL for retrieving license information with Xray.
+     * Artifactory URL for retrieving license information with Xray.
      */
     @Parameter( property = "artifactoryUrl" )
     private String artifactoryUrl;
 
     /**
-     * Artifactory repository access token for retrieving license information with Xray.
+     * Artifactory access token for retrieving license information with Xray.
      */
     @Parameter( property = "artifactoryAccessToken" )
     private String artifactoryAccessToken;

--- a/src/main/java/org/codehaus/mojo/license/AbstractDownloadLicensesMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractDownloadLicensesMojo.java
@@ -225,14 +225,14 @@ public abstract class AbstractDownloadLicensesMojo
     /**
      * Artifactory repository URL for retrieving license information with Xray.
      */
-    @Parameter(property = "artifactRepositoryUrl")
-    private String artifactRepositoryUrl;
+    @Parameter(property = "artifactoryUrl")
+    private String artifactoryUrl;
 
     /**
      * Artifactory repository access token for retrieving license information with Xray.
      */
-    @Parameter(property = "artifactRepositoryAccessToken")
-    private String artifactRepositoryAccessToken;
+    @Parameter(property = "artifactoryAccessToken")
+    private String artifactoryAccessToken;
 
     /**
      * A flag indicating whether to retrieve license information from the Sonatype Processor.
@@ -414,7 +414,7 @@ public abstract class AbstractDownloadLicensesMojo
     private LicenseMap calculateLicenseMap(SortedMap<String, MavenProject> projectDependenciesMap, Set<MavenProject> dependencies) throws MojoFailureException {
         ThirdPartyHelper thirdPartyHelper =
                 new DefaultThirdPartyHelper(project, getEncoding(), isVerbose(), dependenciesTool, thirdPartyTool, localRepository,
-                        project.getRemoteArtifactRepositories(), getLog(), artifactRepositoryUrl, artifactRepositoryAccessToken,
+                        project.getRemoteArtifactRepositories(), getLog(), artifactoryUrl, artifactoryAccessToken,
                         isUseSonatypeProcessor, isUseXrayProcessor);
         LicenseMap licenseMap = thirdPartyHelper.createLicenseMap(dependencies, proxyUrl);
 

--- a/src/main/java/org/codehaus/mojo/license/AbstractDownloadLicensesMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractDownloadLicensesMojo.java
@@ -223,13 +223,13 @@ public abstract class AbstractDownloadLicensesMojo
     List<String> licenseMerges = new ArrayList<>();
 
     /**
-     * Artifactory repository URL for retrieving license information with Xray.
+     * Artifactory URL for retrieving license information with Xray.
      */
     @Parameter(property = "artifactoryUrl")
     private String artifactoryUrl;
 
     /**
-     * Artifactory repository access token for retrieving license information with Xray.
+     * Artifactory access token for retrieving license information with Xray.
      */
     @Parameter(property = "artifactoryAccessToken")
     private String artifactoryAccessToken;

--- a/src/main/java/org/codehaus/mojo/license/AbstractThirdPartyReportMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractThirdPartyReportMojo.java
@@ -238,14 +238,14 @@ public abstract class AbstractThirdPartyReportMojo extends AbstractMavenReport i
     /**
      * Artifactory repository URL for retrieving license information with Xray.
      */
-    @Parameter( property = "artifactRepositoryUrl" )
-    private String artifactRepositoryUrl;
+    @Parameter( property = "artifactoryUrl" )
+    private String artifactoryUrl;
 
     /**
      * Artifactory repository access token for retrieving license information with Xray.
      */
-    @Parameter( property = "artifactRepositoryAccessToken" )
-    private String artifactRepositoryAccessToken;
+    @Parameter( property = "artifactoryAccessToken" )
+    private String artifactoryAccessToken;
 
     /**
      * A flag indicating whether to retrieve license information from the Sonatype Processor.
@@ -497,8 +497,8 @@ public abstract class AbstractThirdPartyReportMojo extends AbstractMavenReport i
 
         ThirdPartyHelper thirdPartyHelper =
                 new DefaultThirdPartyHelper( project, encoding, verbose, dependenciesTool, thirdPartyTool, localRepository,
-                                             project.getRemoteArtifactRepositories(), getLog(), artifactRepositoryUrl,
-                                             artifactRepositoryAccessToken, isUseSonatypeProcessor, isUseXrayProcessor );
+                                             project.getRemoteArtifactRepositories(), getLog(), artifactoryUrl,
+                                             artifactoryAccessToken, isUseSonatypeProcessor, isUseXrayProcessor );
         // load dependencies of the project
         SortedMap<String, MavenProject> projectDependencies = thirdPartyHelper.loadDependencies( this );
 

--- a/src/main/java/org/codehaus/mojo/license/AbstractThirdPartyReportMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractThirdPartyReportMojo.java
@@ -236,13 +236,13 @@ public abstract class AbstractThirdPartyReportMojo extends AbstractMavenReport i
     private MavenProject project;
 
     /**
-     * Artifactory repository URL for retrieving license information with Xray.
+     * Artifactory URL for retrieving license information with Xray.
      */
     @Parameter( property = "artifactoryUrl" )
     private String artifactoryUrl;
 
     /**
-     * Artifactory repository access token for retrieving license information with Xray.
+     * Artifactory access token for retrieving license information with Xray.
      */
     @Parameter( property = "artifactoryAccessToken" )
     private String artifactoryAccessToken;

--- a/src/main/java/org/codehaus/mojo/license/api/DefaultThirdPartyHelper.java
+++ b/src/main/java/org/codehaus/mojo/license/api/DefaultThirdPartyHelper.java
@@ -228,6 +228,10 @@ public class DefaultThirdPartyHelper
         }
 
         if (isUseXrayProcessor) {
+            if (artifactoryUrl == null || artifactoryAccessToken == null) {
+                throw new IllegalArgumentException("Either Environment variable or JVM argument for set 'artifactoryUrl' and 'artifactoryAccessToken' must be provided");
+            }
+
             try {
                 new URL(artifactoryUrl);
             } catch (MalformedURLException e) {

--- a/src/main/java/org/codehaus/mojo/license/api/DefaultThirdPartyHelper.java
+++ b/src/main/java/org/codehaus/mojo/license/api/DefaultThirdPartyHelper.java
@@ -105,12 +105,12 @@ public class DefaultThirdPartyHelper
     /**
      * Artifactory URL for Xray license info.
      */
-    private final String artifactRepositoryUrl;
+    private final String artifactoryUrl;
 
     /**
      * Artifactory access token for Xray.
      */
-    private final String artifactRepositoryAccessToken;
+    private final String artifactoryAccessToken;
 
     /**
      * Flag to use Sonatype Processor for license info.
@@ -138,7 +138,7 @@ public class DefaultThirdPartyHelper
     public DefaultThirdPartyHelper( MavenProject project, String encoding, boolean verbose,
                                     DependenciesTool dependenciesTool, ThirdPartyTool thirdPartyTool,
                                     ArtifactRepository localRepository, List<ArtifactRepository> remoteRepositories,
-                                    Log log, String artifactRepositoryUrl, String artifactRepositoryAccessToken,
+                                    Log log, String artifactoryUrl, String artifactoryAccessToken,
                                     Boolean isUseSonatypeProcessor, Boolean isUseXrayProcessor)
     {
         this.project = project;
@@ -150,8 +150,8 @@ public class DefaultThirdPartyHelper
         this.remoteRepositories = remoteRepositories;
         this.log = log;
         this.thirdPartyTool.setVerbose( verbose );
-        this.artifactRepositoryUrl = artifactRepositoryUrl;
-        this.artifactRepositoryAccessToken = artifactRepositoryAccessToken;
+        this.artifactoryUrl = artifactoryUrl;
+        this.artifactoryAccessToken = artifactoryAccessToken;
         this.isUseSonatypeProcessor = isUseSonatypeProcessor;
         this.isUseXrayProcessor = isUseXrayProcessor;
     }
@@ -225,8 +225,8 @@ public class DefaultThirdPartyHelper
         }
 
         if (isUseXrayProcessor) {
-            if (artifactRepositoryUrl == null || artifactRepositoryAccessToken == null) {
-                throw new IllegalArgumentException("Either Environment variable or JVM argument for set 'artifactRepositoryUrl' and 'artifactRepositoryAccessToken' must be provided");
+            if (artifactoryUrl == null || artifactoryAccessToken == null) {
+                throw new IllegalArgumentException("Either Environment variable or JVM argument for set 'artifactoryUrl' and 'artifactoryAccessToken' must be provided");
             }
             updateLicensesWithInfoFromXRay(licenseMap);
         }
@@ -246,7 +246,7 @@ public class DefaultThirdPartyHelper
 
             Set<MavenProject> projectsToIterate = new TreeSet<>(mavenProjects);
 
-            LicenseProcessor licenseProcessor = new XrayLicenseProcessor(log, artifactRepositoryUrl, artifactRepositoryAccessToken);
+            LicenseProcessor licenseProcessor = new XrayLicenseProcessor(log, artifactoryUrl, artifactoryAccessToken);
 
             for (MavenProject mavenProject: projectsToIterate) {
                 List<License> licenses = licenseProcessor.getLicensesByProject(mavenProject);

--- a/src/main/java/org/codehaus/mojo/license/api/DefaultThirdPartyHelper.java
+++ b/src/main/java/org/codehaus/mojo/license/api/DefaultThirdPartyHelper.java
@@ -23,6 +23,7 @@ package org.codehaus.mojo.license.api;
  */
 
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.model.License;
@@ -39,6 +40,8 @@ import org.codehaus.mojo.license.xray.XrayLicenseProcessor;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.*;
 
 import static org.codehaus.mojo.license.model.LicenseMap.UNKNOWN_LICENSE_MESSAGE;
@@ -225,9 +228,16 @@ public class DefaultThirdPartyHelper
         }
 
         if (isUseXrayProcessor) {
-            if (artifactoryUrl == null || artifactoryAccessToken == null) {
-                throw new IllegalArgumentException("Either Environment variable or JVM argument for set 'artifactoryUrl' and 'artifactoryAccessToken' must be provided");
+            try {
+                new URL(artifactoryUrl);
+            } catch (MalformedURLException e) {
+                throw new IllegalArgumentException("The provided Artifactory URL is not valid: " + artifactoryUrl);
             }
+
+            if (StringUtils.isBlank(artifactoryAccessToken)) {
+                throw new IllegalArgumentException("The Artifactory access token cannot be blank or null");
+            }
+
             updateLicensesWithInfoFromXRay(licenseMap);
         }
 

--- a/src/main/java/org/codehaus/mojo/license/xray/ComponentInfo.java
+++ b/src/main/java/org/codehaus/mojo/license/xray/ComponentInfo.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Collections;
 import java.util.List;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -12,7 +13,7 @@ public class ComponentInfo {
     private List<ComponentData> data;
 
     public List<ComponentData> getData() {
-        return data;
+        return data == null ? Collections.emptyList() : data;
     }
 
     public void setData(List<ComponentData> data) {

--- a/src/main/java/org/codehaus/mojo/license/xray/ComponentInfo.java
+++ b/src/main/java/org/codehaus/mojo/license/xray/ComponentInfo.java
@@ -3,8 +3,9 @@ package org.codehaus.mojo.license.xray;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 
-import java.util.Collections;
 import java.util.List;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -13,9 +14,10 @@ public class ComponentInfo {
     private List<ComponentData> data;
 
     public List<ComponentData> getData() {
-        return data == null ? Collections.emptyList() : data;
+        return data;
     }
 
+    @JsonSetter(nulls = Nulls.AS_EMPTY)
     public void setData(List<ComponentData> data) {
         this.data = data;
     }

--- a/src/main/java/org/codehaus/mojo/license/xray/XrayLicenseProcessor.java
+++ b/src/main/java/org/codehaus/mojo/license/xray/XrayLicenseProcessor.java
@@ -23,7 +23,7 @@ public class XrayLicenseProcessor implements LicenseProcessor {
     private final String baseUrl;
     private final Log log;
     private final String accessToken;
-    private static final String UNKNOWN_LICENSE_MESSAGE = "Unknown";
+    private static final String UNKNOWN_XRAY_LICENSE = "Unknown";
 
     public XrayLicenseProcessor(Log log, String artifactoryUrl, String artifactoryAccessToken) {
         this.log = log;
@@ -63,7 +63,7 @@ public class XrayLicenseProcessor implements LicenseProcessor {
         License license = new License();
 
 //        Change the Unknown license name to the default Unknown License Message
-        if (licenseName.equals(UNKNOWN_LICENSE_MESSAGE)) {
+        if (licenseName.equals(UNKNOWN_XRAY_LICENSE)) {
             license.setName(LicenseMap.UNKNOWN_LICENSE_MESSAGE);
         } else {
             license.setName(licenseName);

--- a/src/main/java/org/codehaus/mojo/license/xray/XrayLicenseProcessor.java
+++ b/src/main/java/org/codehaus/mojo/license/xray/XrayLicenseProcessor.java
@@ -25,10 +25,10 @@ public class XrayLicenseProcessor implements LicenseProcessor {
     private final String accessToken;
     private static final String UNKNOWN_LICENSE_MESSAGE = "Unknown";
 
-    public XrayLicenseProcessor(Log log, String artifactRepositoryUrl, String artifactRepositoryAccessToken) {
+    public XrayLicenseProcessor(Log log, String artifactoryUrl, String artifactoryAccessToken) {
         this.log = log;
-        this.baseUrl = artifactRepositoryUrl;
-        this.accessToken = artifactRepositoryAccessToken;
+        this.baseUrl = artifactoryUrl;
+        this.accessToken = artifactoryAccessToken;
     }
 
     List<License> getLicenseFromJson(String responseStr) throws IOException {

--- a/src/main/java/org/codehaus/mojo/license/xray/XrayLicenseProcessor.java
+++ b/src/main/java/org/codehaus/mojo/license/xray/XrayLicenseProcessor.java
@@ -31,11 +31,11 @@ public class XrayLicenseProcessor implements LicenseProcessor {
         this.accessToken = artifactoryAccessToken;
     }
 
-    List<License> getLicenseFromJson(String responseStr) throws IOException {
+    List<License> getLicenseFromJson(String responseStr, MavenProject project) throws IOException {
         ComponentInfo componentInfo = parseJSON(responseStr);
 
         if (componentInfo.getData().isEmpty()) {
-            log.debug("\tCan't find any licenses");
+            log.info("\tXRray couldn't find any licenses for: " + toString(project));
         } else {
             log.debug("\tFound licenses:");
         }
@@ -95,7 +95,7 @@ public class XrayLicenseProcessor implements LicenseProcessor {
 
             if (statusCode == HttpStatus.SC_OK) {
                 String responseStr = EntityUtils.toString(httpResponse.getEntity());
-                return getLicenseFromJson(responseStr);
+                return getLicenseFromJson(responseStr, project);
             } else {
                 log.error("Unknown status code for " + toString(project) + " : " + statusCode);
             }

--- a/src/test/java/org/codehaus/mojo/license/xray/XrayLicenseProcessorTest.java
+++ b/src/test/java/org/codehaus/mojo/license/xray/XrayLicenseProcessorTest.java
@@ -64,7 +64,7 @@ public class XrayLicenseProcessorTest {
     public void testGetLicenseFromJson() throws IOException {
         String data = loadToString("xrayLicenseInfo.json");
 
-        List<License> licenses = licenseProcessor.getLicenseFromJson(data);
+        List<License> licenses = licenseProcessor.getLicenseFromJson(data, new MavenProject());
 
         Assert.assertEquals(2, licenses.size());
         Assert.assertEquals("license 1", licenses.get(0).getName());

--- a/src/test/java/org/codehaus/mojo/license/xray/XrayLicenseProcessorTest.java
+++ b/src/test/java/org/codehaus/mojo/license/xray/XrayLicenseProcessorTest.java
@@ -52,6 +52,15 @@ public class XrayLicenseProcessorTest {
     }
 
     @Test
+    public void testParseNullDataJSON() throws IOException {
+        String data = loadToString("xrayLicenseEmptyInfo.json");
+        ComponentInfo componentInfo = licenseProcessor.parseJSON(data);
+
+        Assert.assertNotNull(componentInfo);
+        Assert.assertEquals(0, componentInfo.getData().size());
+    }
+
+    @Test
     public void testGetLicenseFromJson() throws IOException {
         String data = loadToString("xrayLicenseInfo.json");
 
@@ -76,6 +85,21 @@ public class XrayLicenseProcessorTest {
         Assert.assertNotNull(licenses);
         Assert.assertEquals(1, licenses.size());
         Assert.assertEquals("Apache-2.0", licenses.get(0).getName());
+    }
+
+    @Test
+    public void testGetNullLicenseByProject() {
+        if (artifactUrl == null || accessToken == null) return;
+
+        MavenProject mavenProject = new MavenProject();
+        mavenProject.setGroupId("com.oracle.jdbc");
+        mavenProject.setArtifactId("ojdbc8");
+        mavenProject.setVersion("18.3.0.0");
+
+        List<License> licenses = licenseProcessor.getLicensesByProject(mavenProject);
+
+        Assert.assertNotNull(licenses);
+        Assert.assertEquals(0, licenses.size());
     }
 
 

--- a/src/test/java/org/codehaus/mojo/license/xray/XrayLicenseProcessorTest.java
+++ b/src/test/java/org/codehaus/mojo/license/xray/XrayLicenseProcessorTest.java
@@ -22,8 +22,8 @@ public class XrayLicenseProcessorTest {
 
     @Before
     public void setUp() {
-        artifactUrl = System.getProperty("artifactRepositoryUrl");
-        accessToken = System.getProperty("artifactRepositoryAccessToken");
+        artifactUrl = System.getProperty("artifactoryUrl");
+        accessToken = System.getProperty("artifactoryAccessToken");
         licenseProcessor = new XrayLicenseProcessor(log, artifactUrl, accessToken);
     }
 

--- a/src/test/resources/xrayLicenseEmptyInfo.json
+++ b/src/test/resources/xrayLicenseEmptyInfo.json
@@ -1,0 +1,1 @@
+{"data":null,"offset":-1}


### PR DESCRIPTION
- Change parameter names from `artifactRepositoryUrl` to `artifactoryUrl` and `artifactRepositoryAccessToken` to `artifactoryAccessToken`
- Handle null data in Xray response
- Add validation to ensure `artifactoryUrl` is in a valid URL format and `artifactoryAccessToken` is not blank or null when the `license.useXrayProcessor` parameter is set to `true`