### PR TITLE
Version Range for Third Party Licenses

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.octopusden.octopus.releng</groupId>
+            <artifactId>versions-api</artifactId>
+            <version>2.0.9</version>
+        </dependency>
+        <dependency>
             <groupId>com.platformlib</groupId>
             <artifactId>platformlib-process-local</artifactId>
             <version>0.1.1</version>

--- a/src/main/java/org/codehaus/mojo/license/api/DefaultThirdPartyTool.java
+++ b/src/main/java/org/codehaus/mojo/license/api/DefaultThirdPartyTool.java
@@ -731,12 +731,8 @@ public class DefaultThirdPartyTool
         // Ensure versionIdRanges is in the correct format ( must start and end with [ or ( and ) or ] )
         String versionIdRanges = overrideVersionId.matches("^[\\[(].*[\\])]$") ? overrideVersionId : "[" + overrideVersionId + "]";
 
-        // Compile the project name pattern (group and artifact ID)
-        String projectNamePatternString = String.format("^%s--%s--.*$", overrideGroupId, overrideArtifactId);
-        Pattern projectNamePattern = Pattern.compile(projectNamePatternString);
-
         return artifactCache.entrySet().stream()
-                .filter(entry -> projectNamePattern.matcher(entry.getKey()).matches())
+                .filter(entry -> entry.getValue().getGroupId().equals(overrideGroupId) && entry.getValue().getArtifactId().equals(overrideArtifactId))
                 .filter(entry -> {
                     getLogger().debug("Version check for " + entry.getKey());
                     getLogger().debug("\tVersion ranges: " + versionIdRanges);

--- a/src/main/java/org/codehaus/mojo/license/api/DefaultThirdPartyTool.java
+++ b/src/main/java/org/codehaus/mojo/license/api/DefaultThirdPartyTool.java
@@ -717,7 +717,7 @@ public class DefaultThirdPartyTool
         licenseMap.removeEmptyLicenses();
     }
 
-    private List<MavenProject> getProjectFromCustomOverrideFile(String id, SortedMap<String, MavenProject> artifactCache, VersionRangeFactory versionRangeFactory, NumericVersionFactory numericVersionFactory) {
+    public List<MavenProject> getProjectFromCustomOverrideFile(String id, SortedMap<String, MavenProject> artifactCache, VersionRangeFactory versionRangeFactory, NumericVersionFactory numericVersionFactory) {
         String[] overrideProjectGAV = id.split("--");
 
         if (overrideProjectGAV.length != 3) {

--- a/src/main/java/org/codehaus/mojo/license/api/DefaultThirdPartyTool.java
+++ b/src/main/java/org/codehaus/mojo/license/api/DefaultThirdPartyTool.java
@@ -639,7 +639,7 @@ public class DefaultThirdPartyTool
         {
             String id = (String) o;
 
-            List<MavenProject> projects = getProjectFromCustomOverrideFile(id, artifactCache, versionRangeFactory, numericVersionFactory);
+            List<MavenProject> projects = getProjectFromCustomOverrideFile(id, artifactCache);
 
             if (projects.isEmpty()) {
                 getLogger().warn( "dependency [" + id + "] does not exist in project." );
@@ -685,7 +685,7 @@ public class DefaultThirdPartyTool
         {
             String id = (String) o;
 
-            List<MavenProject> projects = getProjectFromCustomOverrideFile(id, artifactCache, versionRangeFactory, numericVersionFactory);
+            List<MavenProject> projects = getProjectFromCustomOverrideFile(id, artifactCache);
 
             if ( projects.isEmpty() )
             {
@@ -716,10 +716,12 @@ public class DefaultThirdPartyTool
         licenseMap.removeEmptyLicenses();
     }
 
-    public List<MavenProject> getProjectFromCustomOverrideFile(String id, SortedMap<String, MavenProject> artifactCache, VersionRangeFactory versionRangeFactory, NumericVersionFactory numericVersionFactory) {
+    public List<MavenProject> getProjectFromCustomOverrideFile(String id, SortedMap<String, MavenProject> artifactCache) {
+        getLogger().debug("get project for dependency [" + id + "]");
         String[] overrideProjectGAV = id.split("--");
 
         if (overrideProjectGAV.length != 3) {
+            getLogger().warn("id [" + id + "] format is invalid, no project found");
             return Collections.emptyList();
         }
 

--- a/src/main/java/org/codehaus/mojo/license/api/DefaultThirdPartyTool.java
+++ b/src/main/java/org/codehaus/mojo/license/api/DefaultThirdPartyTool.java
@@ -138,6 +138,13 @@ public class DefaultThirdPartyTool
      */
     private final Comparator<MavenProject> projectComparator = MojoHelper.newMavenProjectComparator();
 
+    /**
+     * Version Range.
+     */
+    private final VersionNames versionNames = new VersionNames("", "", "");
+    private final VersionRangeFactory versionRangeFactory = new VersionRangeFactory(versionNames);
+    private final NumericVersionFactory numericVersionFactory = new NumericVersionFactory(versionNames);
+
     private boolean verbose;
 
     /**
@@ -628,10 +635,6 @@ public class DefaultThirdPartyTool
             overrideMappings.load( overrideFile );
         }
 
-        VersionNames versionNames = new VersionNames("", "", "");
-        VersionRangeFactory versionRangeFactory = new VersionRangeFactory(versionNames);
-        NumericVersionFactory numericVersionFactory = new NumericVersionFactory(versionNames);
-
         for ( Object o : overrideMappings.keySet() )
         {
             String id = (String) o;
@@ -677,10 +680,6 @@ public class DefaultThirdPartyTool
         } catch (final IOException ioException) {
             throw new IllegalStateException(ioException);
         }
-
-        VersionNames versionNames = new VersionNames("", "", "");
-        VersionRangeFactory versionRangeFactory = new VersionRangeFactory(versionNames);
-        NumericVersionFactory numericVersionFactory = new NumericVersionFactory(versionNames);
 
         for ( Object o : overrideMappings.keySet() )
         {

--- a/src/test/java/org/codehaus/mojo/license/api/DefaultThirdPartyToolTest.java
+++ b/src/test/java/org/codehaus/mojo/license/api/DefaultThirdPartyToolTest.java
@@ -1,0 +1,193 @@
+package org.codehaus.mojo.license.api;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
+import org.apache.maven.artifact.versioning.VersionRange;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.mojo.license.model.LicenseMap;
+import org.codehaus.plexus.logging.Logger;
+import org.codehaus.plexus.logging.console.ConsoleLogger;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.octopusden.releng.versions.NumericVersionFactory;
+import org.octopusden.releng.versions.VersionNames;
+import org.octopusden.releng.versions.VersionRangeFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.*;
+
+public class DefaultThirdPartyToolTest {
+
+    private DefaultThirdPartyTool thirdPartyTool;
+    private SortedMap<String, MavenProject> artifactCache;
+    private final VersionNames versionNames = new VersionNames("", "", "");
+    private final VersionRangeFactory versionRangeFactory = new VersionRangeFactory(versionNames);
+    private final NumericVersionFactory numericVersionFactory = new NumericVersionFactory(versionNames);
+
+    @Before
+    public void setUp() throws InvalidVersionSpecificationException {
+        thirdPartyTool = new DefaultThirdPartyTool();
+        Logger logger = new ConsoleLogger(ConsoleLogger.LEVEL_INFO, "test");
+        thirdPartyTool.enableLogging(logger);
+
+        initializeArtifactCache();
+    }
+
+    @Test
+    public void testExactVersionMatch() {
+        String id = "group--artifact--1.0";
+
+        List<MavenProject> projects = thirdPartyTool.getProjectFromCustomOverrideFile(id, artifactCache, versionRangeFactory, numericVersionFactory);
+
+        Assert.assertEquals(1, projects.size());
+        Assert.assertEquals(id, toString(projects.get(0)));
+    }
+
+    @Test
+    public void testSingleVersionRangeWithExactMatch() {
+        String id = "group--artifact--[1.0]";
+
+        List<MavenProject> projects = thirdPartyTool.getProjectFromCustomOverrideFile(id, artifactCache, versionRangeFactory, numericVersionFactory);
+
+        Assert.assertEquals(1, projects.size());
+        Assert.assertEquals("group--artifact--1.0", toString(projects.get(0)));
+    }
+
+    @Test
+    public void testVersionRangeInclusive() {
+        String id = "group2--artifact2--[1-0,1-2]";
+
+        List<MavenProject> projects = thirdPartyTool.getProjectFromCustomOverrideFile(id, artifactCache, versionRangeFactory, numericVersionFactory);
+
+        Assert.assertEquals(1, projects.size());
+        Assert.assertEquals("group2--artifact2--1.2", toString(projects.get(0)));
+    }
+
+    @Test
+    public void testVersionRangeExclusiveEnd() {
+        String id = "group3--artifact3--[1-3,1-5)";
+
+        List<MavenProject> projects = thirdPartyTool.getProjectFromCustomOverrideFile(id, artifactCache, versionRangeFactory, numericVersionFactory);
+
+        Assert.assertEquals(1, projects.size());
+        Assert.assertEquals("group3--artifact3--1.3", toString(projects.get(0)));
+    }
+
+    @Test
+    public void testVersionRangeExclusiveStartAndEnd() {
+        String id = "group4--artifact4--(1-3,1-5)";
+
+        List<MavenProject> projects = thirdPartyTool.getProjectFromCustomOverrideFile(id, artifactCache, versionRangeFactory, numericVersionFactory);
+
+        Assert.assertEquals(1, projects.size());
+        Assert.assertEquals("group4--artifact4--1.4", toString(projects.get(0)));
+    }
+
+    @Test
+    public void testVersionRangeExclusiveStartInclusiveEnd() {
+        String id = "group5--artifact5--(1-3,1-5]";
+
+        List<MavenProject> projects = thirdPartyTool.getProjectFromCustomOverrideFile(id, artifactCache, versionRangeFactory, numericVersionFactory);
+
+        Assert.assertEquals(1, projects.size());
+        Assert.assertEquals("group5--artifact5--1.5", toString(projects.get(0)));
+    }
+
+    @Test
+    public void testMultipleRangesMatch() {
+        String id = "group5--artifact5--[1-0,1-2),(1-3,1-5]";
+
+        List<MavenProject> projects = thirdPartyTool.getProjectFromCustomOverrideFile(id, artifactCache, versionRangeFactory, numericVersionFactory);
+
+        Assert.assertEquals(1, projects.size());
+        Assert.assertEquals("group5--artifact5--1.5", toString(projects.get(0)));
+    }
+
+    @Test
+    public void testVersionRangeNoMatchingVersion() {
+        String id = "group--artifact--[1-3,1-5]";
+
+        List<MavenProject> projects = thirdPartyTool.getProjectFromCustomOverrideFile(id, artifactCache, versionRangeFactory, numericVersionFactory);
+
+        Assert.assertEquals(0, projects.size());
+    }
+
+    @Test
+    public void testMultipleRangesNoMatchingVersion() {
+        String id = "group2--artifact2--[1-0,1-2),(1-3,1-5]";
+
+        List<MavenProject> projects = thirdPartyTool.getProjectFromCustomOverrideFile(id, artifactCache, versionRangeFactory, numericVersionFactory);
+
+        Assert.assertEquals(0, projects.size());
+    }
+
+    @Test
+    public void testOverrideLicenses() throws URISyntaxException, IOException {
+        URL resource = getClass().getClassLoader().getResource("license-version-range.properties");
+
+        if (resource != null) {
+            LicenseMap licenseMap = new LicenseMap();
+            File propertiesFile = new File(resource.toURI());
+
+            thirdPartyTool.overrideLicenses(licenseMap, artifactCache, "UTF-8", propertiesFile);
+
+            Assert.assertEquals(5, licenseMap.size());
+            Assert.assertEquals(1, licenseMap.get("License 1").size());
+            Assert.assertTrue(licenseMap.get("License 1").contains(artifactCache.get("group--artifact--1.0")));
+            Assert.assertEquals(1, licenseMap.get("License 2").size());
+            Assert.assertTrue(licenseMap.get("License 2").contains(artifactCache.get("group2--artifact2--1.2")));
+            Assert.assertEquals(1, licenseMap.get("License 3").size());
+            Assert.assertTrue(licenseMap.get("License 3").contains(artifactCache.get("group3--artifact3--1.3")));
+            Assert.assertEquals(1, licenseMap.get("License 4").size());
+            Assert.assertTrue(licenseMap.get("License 4").contains(artifactCache.get("group4--artifact4--1.4")));
+            Assert.assertEquals(1, licenseMap.get("License 5").size());
+            Assert.assertTrue(licenseMap.get("License 5").contains(artifactCache.get("group5--artifact5--1.5")));
+        }
+    }
+
+    private void initializeArtifactCache() throws InvalidVersionSpecificationException {
+        String[] projectArtifacts = {"group--artifact--1.0", "group2--artifact2--1.2", "group3--artifact3--1.3", "group4--artifact4--1.4", "group5--artifact5--1.5"};
+
+        artifactCache = new TreeMap<>();
+
+        for (String artifact : projectArtifacts) {
+            String[] parts = artifact.split("--");
+
+            if (parts.length == 3) {
+                String groupId = parts[0];
+                String artifactId = parts[1];
+                String version = parts[2];
+
+                VersionRange versionRange = VersionRange.createFromVersionSpec(version);
+
+                Artifact projectArtifact = new DefaultArtifact(
+                        groupId,
+                        artifactId,
+                        versionRange,
+                        Artifact.SCOPE_TEST,
+                        "jar",
+                        null,
+                        new org.apache.maven.artifact.handler.DefaultArtifactHandler("jar")
+                );
+
+                MavenProject project = new MavenProject();
+                project.setGroupId(groupId);
+                project.setArtifactId(artifactId);
+                project.setVersion(version);
+                project.setArtifact(projectArtifact);
+
+                artifactCache.put(artifact, project);
+            }
+        }
+    }
+
+    private String toString(MavenProject project) {
+        return project.getGroupId() + "--" + project.getArtifactId() + "--" + project.getVersion();
+    }
+
+}

--- a/src/test/java/org/codehaus/mojo/license/api/DefaultThirdPartyToolTest.java
+++ b/src/test/java/org/codehaus/mojo/license/api/DefaultThirdPartyToolTest.java
@@ -16,7 +16,9 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.*;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
 
 public class DefaultThirdPartyToolTest {
 

--- a/src/test/resources/license-mix-version-format.properties
+++ b/src/test/resources/license-mix-version-format.properties
@@ -1,0 +1,7 @@
+group1--artifact1--1.0=License 1
+group1--artifact1--2.0=License 1
+
+group12--artifact12--[3.5.0]=License 2
+group13--artifact13--[3.0.22-0000]=License 2
+group14--artifact14--[0.7,0.7.157]=License 2
+group15--artifact15--[2.4.13,2.4.46-83]=License 2

--- a/src/test/resources/license-mvn-version-range-format.properties
+++ b/src/test/resources/license-mvn-version-range-format.properties
@@ -1,0 +1,33 @@
+group1--artifact1--(8,)=License 1
+group2--artifact2--(7.7.1-965,)=License 1
+group3--artifact3--(,3)=License 1
+group4--artifact4--(,7.7.1-965]=License 1
+group5--artifact5--(0,2)=License 1
+group6--artifact6--(1.1.114,2)=License 1
+group7--artifact7--(4.84,4.85)=License 1
+group8--artifact8--(0.6-153,0.7)=License 1
+group9--artifact9--(,4.84],[4.85,)=License 1
+group10--artifact10--(,1.39.1),[1.40,)=License 1
+group11--artifact11--(2.4.46-83,2.4.52-231)=License 1
+
+group12--artifact12--[3.5.0]=License 2
+group13--artifact13--[3.0.22-0000]=License 2
+group14--artifact14--[0.7,0.7.157]=License 2
+group15--artifact15--[2.4.13,2.4.46-83]=License 2
+
+group16--artifact16--[5,7)=License 3
+group17--artifact17--[8,9)=License 3
+group18--artifact18--[1.2.0,)=License 3
+group19--artifact19--[2,)=License 3
+group20--artifact20--[38.30,38.99)=License 3
+group21--artifact21--[1.0,1.2.0)=License 3
+group22--artifact22--[2.4.52-231,2.4.53-285)=License 3
+
+group23--artifact23--(1.0.10,1.0.14),(1.0.14,1.1)=License 4
+group24--artifact24--(,3.44.30),(3.46.30,3.47.30-71)=License 4
+group25--artifact25--[1.2.336],[1.2.392]=License 4
+group26--artifact26--[1.0.35-0009],[11.6.1]=License 4
+group27--artifact27--(2.207,2.313),[3,)=License 4
+group28--artifact28--[2.313],[2.315,3)=License 4
+group29--artifact29--[52.0.1,52.0.1-6),(52.0.1-21,)=License 4
+group30--artifact30--[1.2,1.2.336),(1.2.336,1.2.392),(1.2.392,1.3)=License 4

--- a/src/test/resources/license-scalar-version-format.properties
+++ b/src/test/resources/license-scalar-version-format.properties
@@ -1,0 +1,6 @@
+group1--artifact1--1.0=License 1
+group1--artifact1--2.0=License 1
+group2--artifact2--1.0.RELEASE=License 2
+group2--artifact2--2.0.RELEASE=License 2
+group2--artifact2--3.0.RELEASE=License 2
+group3--artifact3--3.2.1=License 3

--- a/src/test/resources/license-version-range.properties
+++ b/src/test/resources/license-version-range.properties
@@ -1,9 +1,0 @@
-group--artifact--1.0=License 1
-group--artifact--[1.0]=License 1
-group--artifact--[1-3,1-5]=License 1
-group2--artifact2--[1-0,1-2]=License 2
-group2--artifact2--[1-0,1-2),(1-3,1-5]=License 2
-group3--artifact3--[1-3,1-5)=License 3
-group4--artifact4--(1-3,1-5)=License 4
-group5--artifact5--(1-3,1-5]=License 5
-group5--artifact5--[1-0,1-2),(1-3,1-5]=License 5

--- a/src/test/resources/license-version-range.properties
+++ b/src/test/resources/license-version-range.properties
@@ -1,0 +1,9 @@
+group--artifact--1.0=License 1
+group--artifact--[1.0]=License 1
+group--artifact--[1-3,1-5]=License 1
+group2--artifact2--[1-0,1-2]=License 2
+group2--artifact2--[1-0,1-2),(1-3,1-5]=License 2
+group3--artifact3--[1-3,1-5)=License 3
+group4--artifact4--(1-3,1-5)=License 4
+group5--artifact5--(1-3,1-5]=License 5
+group5--artifact5--[1-0,1-2),(1-3,1-5]=License 5


### PR DESCRIPTION
- Added support for version range declarations in `thirdparty-licenses.properties` within the license registry.
- The version range format adheres to the specifications provided in the [Octopus Versions API](https://github.com/octopusden/octopus-versions-api).