### PR TITLE
Enable Maven Invoker integration tests in GitHub CI

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -38,4 +38,4 @@ jobs:
           cache: maven
 
       - name: Build with Maven
-        run: ./mvnw --errors --batch-mode --show-version -D"invoker.streamLogsOnFailures" -P run-its verify
+        run: mvn --errors --batch-mode --show-version -D"invoker.streamLogsOnFailures" -P run-its verify

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -22,4 +22,20 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   build:
     name: Verify
-    uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v3
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '8'
+          distribution: zulu
+          cache: maven
+
+      - name: Build with Maven
+        run: ./mvnw --errors --batch-mode --show-version -D"invoker.streamLogsOnFailures" -P run-its verify

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -23,34 +23,3 @@ jobs:
   build:
     name: Verify
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v3
-
-  integration-tests:
-    name: Invoker IT
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Java
-        uses: actions/setup-java@v4
-        with:
-          java-version: '8'
-          distribution: temurin
-
-      - name: Run Maven Invoker integration tests
-        run: >
-          mvn --batch-mode --update-snapshots
-          -P run-its
-          package
-          invoker:install@all-integration-test
-          invoker:run@all-integration-test
-          invoker:run@integration-test-offline
-
-      - name: Run proxy integration test
-        run: >
-          mvn --batch-mode
-          -P run-its
-          groovy:execute@LittleProxyStart
-          invoker:run@integration-test-proxy
-          groovy:execute@LittleProxyStop

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,9 +17,40 @@
 
 name: GitHub CI
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
     name: Verify
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v3
+
+  integration-tests:
+    name: Invoker IT
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '8'
+          distribution: temurin
+
+      - name: Run Maven Invoker integration tests
+        run: >
+          mvn --batch-mode --update-snapshots
+          -P run-its
+          package
+          invoker:install@all-integration-test
+          invoker:run@all-integration-test
+          invoker:run@integration-test-offline
+
+      - name: Run proxy integration test
+        run: >
+          mvn --batch-mode
+          -P run-its
+          groovy:execute@LittleProxyStart
+          invoker:run@integration-test-proxy
+          groovy:execute@LittleProxyStop

--- a/pom.xml
+++ b/pom.xml
@@ -510,7 +510,6 @@
                     <pomExclude>download-licenses-proxy/pom.xml</pomExclude>
                     <!-- failed test on GH use remote resources -->
                     <pomExclude>download-licenses-basic/pom.xml</pomExclude>
-                    <pomExclude>download-licenses-configured/pom.xml</pomExclude>
                     <pomExclude>download-licenses-force/pom.xml</pomExclude>
                   </pomExcludes>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -510,6 +510,7 @@
                     <pomExclude>download-licenses-proxy/pom.xml</pomExclude>
                     <!-- failed test on GH use remote resources -->
                     <pomExclude>download-licenses-basic/pom.xml</pomExclude>
+                    <pomExclude>download-licenses-configured/pom.xml</pomExclude>
                     <pomExclude>download-licenses-force/pom.xml</pomExclude>
                   </pomExcludes>
                 </configuration>

--- a/src/it/download-licenses-configured/licenses-pre-1.18.expected.xml
+++ b/src/it/download-licenses-configured/licenses-pre-1.18.expected.xml
@@ -18,8 +18,8 @@
       <licenses>
         <license>
           <name>BSD 3-Clause ASM</name>
-          <url>https://gitlab.ow2.org/asm/asm/raw/ASM_3_1_MVN/LICENSE.txt</url>
-          <file>bsd 3-clause asm - license.txt</file>
+          <url>%project.baseUri%src/license/content-sanitizers/bsd3-asm.txt</url>
+          <file>bsd 3-clause asm - bsd3-asm.txt</file>
         </license>
       </licenses>
     </dependency>
@@ -30,8 +30,8 @@
       <licenses>
         <license>
           <name>Apache License 2.0</name>
-          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-          <file>apache license 2.0 - license-2.0.txt</file>
+          <url>%project.baseUri%src/license/content-sanitizers/apache-2.0.txt</url>
+          <file>apache license 2.0 - apache-2.0.txt</file>
         </license>
       </licenses>
     </dependency>

--- a/src/it/download-licenses-configured/licenses-since-1.18.expected.xml
+++ b/src/it/download-licenses-configured/licenses-since-1.18.expected.xml
@@ -18,8 +18,8 @@
       <licenses>
         <license>
           <name>BSD 3-Clause ASM</name>
-          <url>https://gitlab.ow2.org/asm/asm/raw/ASM_3_1_MVN/LICENSE.txt</url>
-          <file>bsd-3-clause-asm-license.txt</file>
+          <url>%project.baseUri%src/license/content-sanitizers/bsd3-asm.txt</url>
+          <file>bsd-3-clause-asm-bsd3-asm.txt</file>
         </license>
       </licenses>
     </dependency>
@@ -30,8 +30,8 @@
       <licenses>
         <license>
           <name>Apache License 2.0</name>
-          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-          <file>apache-license-2.0-license-2.0.txt</file>
+          <url>%project.baseUri%src/license/content-sanitizers/apache-2.0.txt</url>
+          <file>apache-license-2.0-apache-2.0.txt</file>
         </license>
       </licenses>
     </dependency>

--- a/src/it/download-licenses-configured/postbuild.groovy
+++ b/src/it/download-licenses-configured/postbuild.groovy
@@ -24,38 +24,46 @@ import java.nio.file.Path;
 import java.nio.file.Files;
 
 final Path basePath = basedir.toPath()
+final String baseUri = basePath.toUri().toString()
+
+boolean assertExpectedLicensesXml(final Path expectedLicensesXml, final Path licensesXml, final String baseUri) {
+    String expected = expectedLicensesXml.toFile().text
+    String actual = licensesXml.toFile().text.replace(baseUri, '%project.baseUri%')
+    assert expected.equals(actual)
+    return true
+}
 
 return {
     final String id = 'pre-1.18'
     final Path outputBase = basePath.resolve('target/' + id)
 
-    final Path asl2 = outputBase.resolve('licenses/apache license 2.0 - license-2.0.txt')
+    final Path asl2 = outputBase.resolve('licenses/apache license 2.0 - apache-2.0.txt')
     assert Files.exists(asl2)
     assert asl2.toFile().text.contains('Version 2.0, January 2004')
 
-    final Path bsdAsm = outputBase.resolve('licenses/bsd 3-clause asm - license.txt')
+    final Path bsdAsm = outputBase.resolve('licenses/bsd 3-clause asm - bsd3-asm.txt')
     assert Files.exists(bsdAsm)
     assert bsdAsm.toFile().text.contains('ASM: a very small and fast Java bytecode manipulation framework')
 
     final Path expectedLicensesXml = basePath.resolve('licenses-'+ id +'.expected.xml')
     final Path licensesXml = outputBase.resolve('licenses.xml')
-    assert expectedLicensesXml.toFile().text.equals(licensesXml.toFile().text)
+    assertExpectedLicensesXml(expectedLicensesXml, licensesXml, baseUri)
     return true
 }() && {
     final String id = 'since-1.18'
     final Path outputBase = basePath.resolve('target/' + id)
 
-    final Path asl2 = outputBase.resolve('licenses/apache-license-2.0-license-2.0.txt')
+    final Path asl2 = outputBase.resolve('licenses/apache-license-2.0-apache-2.0.txt')
     assert Files.exists(asl2)
     assert asl2.toFile().text.contains('Version 2.0, January 2004')
 
-    final Path bsdAsm = outputBase.resolve('licenses/bsd-3-clause-asm-license.txt')
+    final Path bsdAsm = outputBase.resolve('licenses/bsd-3-clause-asm-bsd3-asm.txt')
     assert Files.exists(bsdAsm)
     assert bsdAsm.toFile().text.contains('ASM: a very small and fast Java bytecode manipulation framework')
 
     final Path expectedLicensesXml = basePath.resolve('licenses-'+ id +'.expected.xml')
     final Path licensesXml = outputBase.resolve('licenses.xml')
-    assert expectedLicensesXml.toFile().text.equals(licensesXml.toFile().text)
+    assertExpectedLicensesXml(expectedLicensesXml, licensesXml, baseUri)
     return true
 }() && {
     final String id = 'artifact-filters-url'

--- a/src/it/download-licenses-configured/prebuild.groovy
+++ b/src/it/download-licenses-configured/prebuild.groovy
@@ -26,10 +26,16 @@ import java.nio.file.Files;
 final Path basePath = basedir.toPath()
 
 final String baseUri = basePath.toUri().toString()
-final Path sanitizesConfigPath = basePath.resolve('src/license/licenses-config-content-sanitizers.xml');
-String sanitizersConfigContent = new String(Files.readAllBytes(sanitizesConfigPath), 'utf-8')
-sanitizersConfigContent = sanitizersConfigContent.replace('%project.baseUri%', baseUri)
-Files.write(sanitizesConfigPath, sanitizersConfigContent.getBytes('utf-8'))
+[
+    'src/license/licenses-config-pre-1.18.xml',
+    'src/license/licenses-config-since-1.18.xml',
+    'src/license/licenses-config-content-sanitizers.xml'
+].each {
+    final Path configPath = basePath.resolve(it)
+    String configContent = new String(Files.readAllBytes(configPath), 'utf-8')
+    configContent = configContent.replace('%project.baseUri%', baseUri)
+    Files.write(configPath, configContent.getBytes('utf-8'))
+}
 
 Files.move(basePath.resolve('target-initial'), basePath.resolve('target'))
 

--- a/src/it/download-licenses-configured/src/license/licenses-config-pre-1.18.xml
+++ b/src/it/download-licenses-configured/src/license/licenses-config-pre-1.18.xml
@@ -6,7 +6,7 @@
       <licenses>
         <license>
           <name>Apache License 2.0</name>
-          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+          <url>%project.baseUri%src/license/content-sanitizers/apache-2.0.txt</url>
         </license>
       </licenses>
     </dependency>
@@ -21,7 +21,7 @@
       <licenses>
         <license>
           <name>BSD 3-Clause ASM</name>
-          <url>https://gitlab.ow2.org/asm/asm/raw/ASM_3_1_MVN/LICENSE.txt</url>
+          <url>%project.baseUri%src/license/content-sanitizers/bsd3-asm.txt</url>
         </license>
       </licenses>
     </dependency>

--- a/src/it/download-licenses-configured/src/license/licenses-config-since-1.18.xml
+++ b/src/it/download-licenses-configured/src/license/licenses-config-since-1.18.xml
@@ -10,7 +10,7 @@
       <licenses>
         <license>
           <name>Apache License 2.0</name>
-          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+          <url>%project.baseUri%src/license/content-sanitizers/apache-2.0.txt</url>
         </license>
       </licenses>
     </dependency>
@@ -33,7 +33,7 @@
       <licenses>
         <license>
           <name>BSD 3-Clause ASM</name>
-          <url>https://gitlab.ow2.org/asm/asm/raw/ASM_3_1_MVN/LICENSE.txt</url>
+          <url>%project.baseUri%src/license/content-sanitizers/bsd3-asm.txt</url>
         </license>
       </licenses>
     </dependency>


### PR DESCRIPTION
## Summary

This PR restores execution of Maven Invoker integration tests (`src/it`) in GitHub Actions for the upstream `main` line of the plugin.

**Problem:** GitHub CI was not running the plugin's integration test suite. The existing workflow delegated to Apache's reusable `maven-verify.yml`, which runs a broad OS/JDK/Maven matrix and did not reliably exercise this project's `-P run-its` invoker profile. In practice, the ~86 invoker projects under `src/it` were not being validated on every push/PR.

**Fix:**
- Replace the generic Apache matrix workflow with a focused local job: Ubuntu, Java 8, `mvn -P run-its verify`
- Use the Maven installed on the GitHub runner (this fork's `mvnw` is incomplete — no wrapper bootstrap jar)
- Fix the flaky `download-licenses-configured` IT by pointing license URLs at local fixtures instead of live Apache/GitLab URLs whose response `Content-Type` caused non-deterministic downloaded filenames on CI

**What runs now (84 of 86 IT projects):**
- Main invoker batch: ~82 projects via `all-integration-test`
- `MLICENSE-4`: separate offline execution
- `download-licenses-proxy`: separate proxy execution (LittleProxy)

**Still excluded from the main batch (pre-existing, unchanged):**
- `download-licenses-basic` — depends on live remote license URLs
- `download-licenses-force` — depends on live remote license URLs

These two can be fixed the same way as `download-licenses-configured` if we want 86/86 coverage.

**Note on branch target:** `enable-github-invoker-its` is based on `main` (5 commits). The org default branch `octopus` is a separate lineage (`octopus-parent`, different CI via `build.yml`). If this needs to land on `octopus`, the workflow/IT changes should be cherry-picked or ported there separately.

## Test plan

- [x] GitHub CI green on `enable-github-invoker-its` ([latest run](https://github.com/octopusden/octopus-license-maven-plugin/actions/runs/27704816582))
- [x] `download-licenses-configured` IT re-enabled (no longer in `pomExcludes`)
- [ ] Reviewer confirms `main` is the intended merge target (vs `octopus`)


Made with [Cursor](https://cursor.com)