### PR TITLE
Verify PR #17: full invoker IT suite

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -11,16 +11,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: ['8', '11', '17', '21', '25']
-        maven: ['3.6.3', '3.8.8', '3.9.9']
-        exclude:
-          # Maven 3.6.x lacks --add-opens for the Java 9+ module system
-          - java: '17'
-            maven: '3.6.3'
-          - java: '21'
-            maven: '3.6.3'
-          - java: '25'
-            maven: '3.6.3'
+        # Full invoker suite is slow; use one representative cell for PR #17 verification.
+        include:
+          - java: '8'
+            maven: '3.9.9'
 
     steps:
       - uses: actions/checkout@v4
@@ -50,4 +44,4 @@ jobs:
         run: mvn --version
 
       - name: Build and run integration tests
-        run: mvn verify -P run-its -Dmaven.javadoc.skip=true -B
+        run: mvn --errors --batch-mode --show-version -Dinvoker.streamLogsOnFailures verify -P run-its -Dmaven.javadoc.skip=true

--- a/pom.xml
+++ b/pom.xml
@@ -484,21 +484,14 @@
                                 </goals>
                                 <configuration>
                                     <skipInvocation>false</skipInvocation>
-                                    <!--<extraArtifacts>-->
-                                    <!--<extraArtifact>-->
-                                    <!--${project.groupId}:${project.artifactId}:${project.version}:license.properties:test-third-party-->
-                                    <!--</extraArtifact>-->
-                                    <!--</extraArtifacts>-->
-                                    <!--<pomExcludes>-->
-                                    <!--<pomExclude>MLICENSE-4/pom.xml</pomExclude>-->
-                                    <!--</pomExcludes>-->
-                                    <pomIncludes>
-                                        <pomInclude>jars-json-list-test-mojo/pom.xml</pomInclude>
-                                        <!-- Verifies Plexus DI wiring of ProjectBuilder, ProjectDependenciesResolver,
-                                             LegacySupport and Aether RepositorySystem on each Maven version.
-                                             Uses license.skip=true so no external license registry is needed. -->
-                                        <pomInclude>maven-api-compat/pom.xml</pomInclude>
-                                    </pomIncludes>
+                                    <extraArtifacts>
+                                        <extraArtifact>${project.groupId}:${project.artifactId}:${project.version}:license.properties:test-third-party</extraArtifact>
+                                    </extraArtifacts>
+                                    <pomExcludes>
+                                        <pomExclude>MLICENSE-4/pom.xml</pomExclude>
+                                        <!-- depends on live remote license URLs -->
+                                        <pomExclude>download-licenses-basic/pom.xml</pomExclude>
+                                    </pomExcludes>
                                 </configuration>
                             </execution>
                             <!-- as this it is run in offline, then execute it after the previous its... -->
@@ -508,10 +501,11 @@
                                     <goal>run</goal>
                                 </goals>
                                 <configuration>
-                                    <skipInvocation>true</skipInvocation>
+                                    <skipInvocation>false</skipInvocation>
                                     <pomIncludes>
                                         <pomInclude>MLICENSE-4/pom.xml</pomInclude>
                                     </pomIncludes>
+                                    <cloneProjectsTo>${project.build.directory}/it-offline</cloneProjectsTo>
                                 </configuration>
                             </execution>
                         </executions>

--- a/src/it/ISSUE-21/pom.xml
+++ b/src/it/ISSUE-21/pom.xml
@@ -34,7 +34,7 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>org.octopusden.octopus</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>@pom.version@</version>
         </plugin>

--- a/src/it/ISSUE-22/pom.xml
+++ b/src/it/ISSUE-22/pom.xml
@@ -33,7 +33,7 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>org.octopusden.octopus</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>@pom.version@</version>
         </plugin>

--- a/src/it/ISSUE-31/child2/pom.xml
+++ b/src/it/ISSUE-31/child2/pom.xml
@@ -18,7 +18,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>org.octopusden.octopus</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <configuration>
           <encoding>UTF-8</encoding>

--- a/src/it/ISSUE-31/pom.xml
+++ b/src/it/ISSUE-31/pom.xml
@@ -15,7 +15,7 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>org.octopusden.octopus</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>@project.version@</version>
         </plugin>

--- a/src/it/ISSUE-38/pom.xml
+++ b/src/it/ISSUE-38/pom.xml
@@ -33,7 +33,7 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>org.octopusden.octopus</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>@pom.version@</version>
           <configuration>

--- a/src/it/ISSUE-40/pom.xml
+++ b/src/it/ISSUE-40/pom.xml
@@ -32,7 +32,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>org.octopusden.octopus</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <version>@pom.version@</version>
         <executions>

--- a/src/it/ISSUE-55/pom.xml
+++ b/src/it/ISSUE-55/pom.xml
@@ -23,7 +23,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>org.octopusden.octopus</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <version>@pom.version@</version>
         <executions>

--- a/src/it/ISSUE-59/pom.xml
+++ b/src/it/ISSUE-59/pom.xml
@@ -75,7 +75,7 @@
       <plugins>
 
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>org.octopusden.octopus</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>@pom.version@</version>
         </plugin>

--- a/src/it/ISSUE-7/pom.xml
+++ b/src/it/ISSUE-7/pom.xml
@@ -34,7 +34,7 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>org.octopusden.octopus</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>@pom.version@</version>
         </plugin>

--- a/src/it/ISSUE-80/pom.xml
+++ b/src/it/ISSUE-80/pom.xml
@@ -73,7 +73,7 @@
       <plugins>
 
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>org.octopusden.octopus</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>@pom.version@</version>
         </plugin>

--- a/src/it/MLICENSE-2/pom.xml
+++ b/src/it/MLICENSE-2/pom.xml
@@ -84,7 +84,7 @@
       <plugins>
 
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>org.octopusden.octopus</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>@pom.version@</version>
         </plugin>

--- a/src/it/MLICENSE-21/pom.xml
+++ b/src/it/MLICENSE-21/pom.xml
@@ -75,7 +75,7 @@
       <plugins>
 
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>org.octopusden.octopus</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>@pom.version@</version>
         </plugin>

--- a/src/it/MLICENSE-23/pom.xml
+++ b/src/it/MLICENSE-23/pom.xml
@@ -55,7 +55,7 @@
       <plugins>
 
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>org.octopusden.octopus</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>@pom.version@</version>
           <configuration>

--- a/src/it/MLICENSE-24/pom.xml
+++ b/src/it/MLICENSE-24/pom.xml
@@ -74,7 +74,7 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>org.octopusden.octopus</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>@pom.version@</version>
         </plugin>
@@ -83,7 +83,7 @@
 
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>org.octopusden.octopus</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <executions>
           <execution>

--- a/src/it/MLICENSE-25/pom.xml
+++ b/src/it/MLICENSE-25/pom.xml
@@ -63,7 +63,7 @@
     <plugins>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>org.octopusden.octopus</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <configuration>
           <outputDirectory>${project.build.directory}</outputDirectory>
@@ -95,7 +95,7 @@
       <plugins>
 
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>org.octopusden.octopus</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>@pom.version@</version>
         </plugin>

--- a/src/it/MLICENSE-27/pom.xml
+++ b/src/it/MLICENSE-27/pom.xml
@@ -45,7 +45,7 @@
       <plugins>
 
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>org.octopusden.octopus</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>@pom.version@</version>
           <configuration>

--- a/src/it/MLICENSE-28/pom.xml
+++ b/src/it/MLICENSE-28/pom.xml
@@ -21,7 +21,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>org.octopusden.octopus</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <version>@project.version@</version>
       </plugin>

--- a/src/it/MLICENSE-3/pom.xml
+++ b/src/it/MLICENSE-3/pom.xml
@@ -45,7 +45,7 @@
       <plugins>
 
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>org.octopusden.octopus</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>@pom.version@</version>
           <configuration>

--- a/src/it/MLICENSE-30/pom.xml
+++ b/src/it/MLICENSE-30/pom.xml
@@ -45,7 +45,7 @@
       <plugins>
 
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>org.octopusden.octopus</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>@pom.version@</version>
           <configuration>

--- a/src/it/MLICENSE-33/pom.xml
+++ b/src/it/MLICENSE-33/pom.xml
@@ -72,7 +72,7 @@
     <plugins>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>org.octopusden.octopus</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <executions>
           <execution>
@@ -87,7 +87,7 @@
       <plugins>
 
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>org.octopusden.octopus</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>@pom.version@</version>
         </plugin>
@@ -104,7 +104,7 @@
     <excludeDefaults>true</excludeDefaults>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>org.octopusden.octopus</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <version>@pom.version@</version>
         <reportSets>

--- a/src/it/MLICENSE-36/pom.xml
+++ b/src/it/MLICENSE-36/pom.xml
@@ -44,7 +44,7 @@
       <plugins>
 
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>org.octopusden.octopus</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>@pom.version@</version>
         </plugin>

--- a/src/it/MLICENSE-37-blacklist-fail/pom.xml
+++ b/src/it/MLICENSE-37-blacklist-fail/pom.xml
@@ -54,7 +54,7 @@
       <plugins>
 
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>org.octopusden.octopus</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>@pom.version@</version>
         </plugin>

--- a/src/it/MLICENSE-37-blacklist-success/pom.xml
+++ b/src/it/MLICENSE-37-blacklist-success/pom.xml
@@ -54,7 +54,7 @@
       <plugins>
 
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>org.octopusden.octopus</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>@pom.version@</version>
         </plugin>

--- a/src/it/MLICENSE-37-whitelist-fail/pom.xml
+++ b/src/it/MLICENSE-37-whitelist-fail/pom.xml
@@ -54,7 +54,7 @@
       <plugins>
 
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>org.octopusden.octopus</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>@pom.version@</version>
         </plugin>

--- a/src/it/MLICENSE-37-whitelist-success/pom.xml
+++ b/src/it/MLICENSE-37-whitelist-success/pom.xml
@@ -54,7 +54,7 @@
       <plugins>
 
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>org.octopusden.octopus</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>@pom.version@</version>
         </plugin>

--- a/src/it/MLICENSE-4/pom.xml
+++ b/src/it/MLICENSE-4/pom.xml
@@ -58,7 +58,7 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>org.octopusden.octopus</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>@pom.version@</version>
         </plugin>

--- a/src/it/MLICENSE-44/pom.xml
+++ b/src/it/MLICENSE-44/pom.xml
@@ -9,7 +9,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>org.octopusden.octopus</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <version>@project.version@</version>
         <configuration>

--- a/src/it/MLICENSE-45/child2/pom.xml
+++ b/src/it/MLICENSE-45/child2/pom.xml
@@ -18,7 +18,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>org.octopusden.octopus</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <configuration>
           <encoding>UTF-8</encoding>

--- a/src/it/MLICENSE-45/pom.xml
+++ b/src/it/MLICENSE-45/pom.xml
@@ -15,7 +15,7 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>org.octopusden.octopus</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>@project.version@</version>
         </plugin>

--- a/src/it/MLICENSE-5/pom.xml
+++ b/src/it/MLICENSE-5/pom.xml
@@ -50,7 +50,7 @@
       <plugins>
 
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>org.octopusden.octopus</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>@pom.version@</version>
         </plugin>
@@ -59,7 +59,7 @@
 
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>org.octopusden.octopus</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <version>@pom.version@</version>
         <executions>

--- a/src/it/MLICENSE-53/pom.xml
+++ b/src/it/MLICENSE-53/pom.xml
@@ -41,7 +41,7 @@
 
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>org.octopusden.octopus</groupId>
         <artifactId>license-maven-plugin</artifactId>
 
         <configuration><failIfWarning>true</failIfWarning></configuration>
@@ -111,7 +111,7 @@
       <plugins>
 
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>org.octopusden.octopus</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>@pom.version@</version>
         </plugin>

--- a/src/it/MLICENSE-55/pom.xml
+++ b/src/it/MLICENSE-55/pom.xml
@@ -25,9 +25,9 @@
     <build>      
         <plugins>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
+                <groupId>org.octopusden.octopus</groupId>
                 <artifactId>license-maven-plugin</artifactId>
-                <version>1.3</version>
+                <version>@pom.version@</version>
                         
                 <executions>
                     <execution>

--- a/src/it/MLICENSE-71/pom.xml
+++ b/src/it/MLICENSE-71/pom.xml
@@ -55,7 +55,7 @@
       <plugins>
 
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>org.octopusden.octopus</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>@pom.version@</version>
           <configuration>

--- a/src/it/MLICENSE-72/pom.xml
+++ b/src/it/MLICENSE-72/pom.xml
@@ -55,7 +55,7 @@
       <plugins>
 
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>org.octopusden.octopus</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>@pom.version@</version>
         </plugin>

--- a/src/it/MLICENSE-92/pom.xml
+++ b/src/it/MLICENSE-92/pom.xml
@@ -49,7 +49,7 @@
       <plugins>
 
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>org.octopusden.octopus</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>@pom.version@</version>
         </plugin>
@@ -58,7 +58,7 @@
 
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>org.octopusden.octopus</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <version>@pom.version@</version>
         <executions>

--- a/src/it/PR-32/child2/pom.xml
+++ b/src/it/PR-32/child2/pom.xml
@@ -18,7 +18,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>org.octopusden.octopus</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <executions>
           <execution>

--- a/src/it/PR-32/pom.xml
+++ b/src/it/PR-32/pom.xml
@@ -16,7 +16,7 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>org.octopusden.octopus</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>@project.version@</version>
         </plugin>

--- a/src/it/PR-33/child3/pom.xml
+++ b/src/it/PR-33/child3/pom.xml
@@ -23,7 +23,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>org.octopusden.octopus</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <executions>
           <execution>

--- a/src/it/PR-33/pom.xml
+++ b/src/it/PR-33/pom.xml
@@ -17,7 +17,7 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>org.octopusden.octopus</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>@project.version@</version>
         </plugin>

--- a/src/it/PR-64-aggregate-unknown-license/pom.xml
+++ b/src/it/PR-64-aggregate-unknown-license/pom.xml
@@ -18,7 +18,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>org.octopusden.octopus</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <version>@project.version@</version>
         <configuration>

--- a/src/it/add-third-party-excluded-included/pom.xml
+++ b/src/it/add-third-party-excluded-included/pom.xml
@@ -70,7 +70,7 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>org.octopusden.octopus</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>@pom.version@</version>
         </plugin>
@@ -79,7 +79,7 @@
 
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>org.octopusden.octopus</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <executions>
           <execution>

--- a/src/it/add-third-party-global-db/pom.xml
+++ b/src/it/add-third-party-global-db/pom.xml
@@ -49,7 +49,7 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>org.octopusden.octopus</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>@pom.version@</version>
           <configuration>

--- a/src/it/add-third-party-merge-licenses/pom.xml
+++ b/src/it/add-third-party-merge-licenses/pom.xml
@@ -78,7 +78,7 @@
 
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>org.octopusden.octopus</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <executions>
           <execution>
@@ -159,7 +159,7 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>org.octopusden.octopus</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>@pom.version@</version>
         </plugin>

--- a/src/it/add-third-party-missing-pom/pom.xml
+++ b/src/it/add-third-party-missing-pom/pom.xml
@@ -57,7 +57,7 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>org.octopusden.octopus</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>@pom.version@</version>
         </plugin>

--- a/src/it/add-third-party-no-deps/pom.xml
+++ b/src/it/add-third-party-no-deps/pom.xml
@@ -44,7 +44,7 @@
       <plugins>
 
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>org.octopusden.octopus</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>@pom.version@</version>
         </plugin>

--- a/src/it/add-third-party-no-encoding/pom.xml
+++ b/src/it/add-third-party-no-encoding/pom.xml
@@ -51,7 +51,7 @@
       <plugins>
 
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>org.octopusden.octopus</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>@pom.version@</version>
         </plugin>

--- a/src/it/aggregate-add-third-party-bad-license/pom.xml
+++ b/src/it/aggregate-add-third-party-bad-license/pom.xml
@@ -53,7 +53,7 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>org.octopusden.octopus</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>@pom.version@</version>
         </plugin>

--- a/src/it/aggregate-add-third-party-exclude-transitive-deps/pom.xml
+++ b/src/it/aggregate-add-third-party-exclude-transitive-deps/pom.xml
@@ -55,7 +55,7 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>org.octopusden.octopus</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>@pom.version@</version>
         </plugin>
@@ -64,7 +64,7 @@
 
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>org.octopusden.octopus</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <executions>
           <execution>

--- a/src/it/aggregate-add-third-party-global-db/consume-db/pom.xml
+++ b/src/it/aggregate-add-third-party-global-db/consume-db/pom.xml
@@ -43,7 +43,7 @@
   </properties>
   <dependencies>
     <dependency>
-      <groupId>org.codehaus.mojo</groupId>
+      <groupId>org.octopusden.octopus</groupId>
       <artifactId>license-maven-plugin</artifactId>
       <classifier>test-third-party</classifier>
       <type>license.properties</type>

--- a/src/it/aggregate-add-third-party-global-db/pom.xml
+++ b/src/it/aggregate-add-third-party-global-db/pom.xml
@@ -38,7 +38,7 @@
         <pluginManagement>
           <plugins>
             <plugin>
-              <groupId>org.codehaus.mojo</groupId>
+              <groupId>org.octopusden.octopus</groupId>
               <artifactId>license-maven-plugin</artifactId>
               <version>@pom.version@</version>
               <configuration>

--- a/src/it/aggregate-add-third-party-multimodule-filters/pom.xml
+++ b/src/it/aggregate-add-third-party-multimodule-filters/pom.xml
@@ -54,7 +54,7 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>org.octopusden.octopus</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>@pom.version@</version>
         </plugin>
@@ -63,7 +63,7 @@
 
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>org.octopusden.octopus</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <executions>
           <execution>

--- a/src/it/download-licenses-basic/pom.xml
+++ b/src/it/download-licenses-basic/pom.xml
@@ -24,7 +24,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>org.octopusden.octopus</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <version>@pom.version@</version>
         <executions>

--- a/src/it/download-licenses-configured-alt-location/pom.xml
+++ b/src/it/download-licenses-configured-alt-location/pom.xml
@@ -24,7 +24,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>org.octopusden.octopus</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <version>@pom.version@</version>
         <executions>

--- a/src/it/download-licenses-configured/pom.xml
+++ b/src/it/download-licenses-configured/pom.xml
@@ -24,7 +24,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>org.octopusden.octopus</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <version>@pom.version@</version>
         <executions>

--- a/src/it/dual-licensed-blacklist/pom.xml
+++ b/src/it/dual-licensed-blacklist/pom.xml
@@ -54,7 +54,7 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
+                    <groupId>org.octopusden.octopus</groupId>
                     <artifactId>license-maven-plugin</artifactId>
                     <version>@pom.version@</version>
                 </plugin>
@@ -63,7 +63,7 @@
 
         <plugins>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
+                <groupId>org.octopusden.octopus</groupId>
                 <artifactId>license-maven-plugin</artifactId>
                 <executions>
                     <execution>

--- a/src/it/dual-licensed-both-whitelisted/pom.xml
+++ b/src/it/dual-licensed-both-whitelisted/pom.xml
@@ -54,7 +54,7 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
+                    <groupId>org.octopusden.octopus</groupId>
                     <artifactId>license-maven-plugin</artifactId>
                     <version>@pom.version@</version>
                 </plugin>
@@ -63,7 +63,7 @@
 
         <plugins>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
+                <groupId>org.octopusden.octopus</groupId>
                 <artifactId>license-maven-plugin</artifactId>
                 <executions>
                     <execution>

--- a/src/it/dual-licensed-none-whitelisted/pom.xml
+++ b/src/it/dual-licensed-none-whitelisted/pom.xml
@@ -54,7 +54,7 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
+                    <groupId>org.octopusden.octopus</groupId>
                     <artifactId>license-maven-plugin</artifactId>
                     <version>@pom.version@</version>
                 </plugin>
@@ -63,7 +63,7 @@
 
         <plugins>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
+                <groupId>org.octopusden.octopus</groupId>
                 <artifactId>license-maven-plugin</artifactId>
                 <executions>
                     <execution>

--- a/src/it/dual-licensed-one-whitelisted/pom.xml
+++ b/src/it/dual-licensed-one-whitelisted/pom.xml
@@ -54,7 +54,7 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
+                    <groupId>org.octopusden.octopus</groupId>
                     <artifactId>license-maven-plugin</artifactId>
                     <version>@pom.version@</version>
                 </plugin>
@@ -63,7 +63,7 @@
 
         <plugins>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
+                <groupId>org.octopusden.octopus</groupId>
                 <artifactId>license-maven-plugin</artifactId>
                 <executions>
                     <execution>

--- a/src/it/settings.xml
+++ b/src/it/settings.xml
@@ -57,6 +57,7 @@
   </profiles>
 
   <pluginGroups>
+    <pluginGroup>org.octopusden.octopus</pluginGroup>
     <pluginGroup>org.codehaus.mojo</pluginGroup>
   </pluginGroups>
 </settings>

--- a/src/it/third-party-report-global-db/consume-db/pom.xml
+++ b/src/it/third-party-report-global-db/consume-db/pom.xml
@@ -43,7 +43,7 @@
   </properties>
   <dependencies>
     <dependency>
-      <groupId>org.codehaus.mojo</groupId>
+      <groupId>org.octopusden.octopus</groupId>
       <artifactId>license-maven-plugin</artifactId>
       <classifier>test-third-party</classifier>
       <type>license.properties</type>

--- a/src/it/third-party-report-global-db/pom.xml
+++ b/src/it/third-party-report-global-db/pom.xml
@@ -38,7 +38,7 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
+                    <groupId>org.octopusden.octopus</groupId>
                     <artifactId>license-maven-plugin</artifactId>
                     <version>@pom.version@</version>
                 </plugin>
@@ -54,7 +54,7 @@
         <excludeDefaults>true</excludeDefaults>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
+                <groupId>org.octopusden.octopus</groupId>
                 <artifactId>license-maven-plugin</artifactId>
                 <version>@pom.version@</version>
                 <reportSets>

--- a/src/it/third-party-report/pom.xml
+++ b/src/it/third-party-report/pom.xml
@@ -78,7 +78,7 @@
     <plugins>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>org.octopusden.octopus</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <executions>
           <execution>
@@ -92,7 +92,7 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>org.octopusden.octopus</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>@pom.version@</version>
         </plugin>
@@ -109,7 +109,7 @@
     <excludeDefaults>true</excludeDefaults>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>org.octopusden.octopus</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <version>@pom.version@</version>
         <reportSets>

--- a/src/it/update-file-header-test-mojo/pom.xml
+++ b/src/it/update-file-header-test-mojo/pom.xml
@@ -52,7 +52,7 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>org.octopusden.octopus</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>@pom.version@</version>
         </plugin>
@@ -62,7 +62,7 @@
     <plugins>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>org.octopusden.octopus</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <configuration>
           <verbose>true</verbose>

--- a/src/it/update-project-license-test-mojo/pom.xml
+++ b/src/it/update-project-license-test-mojo/pom.xml
@@ -54,7 +54,7 @@
       <plugins>
 
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>org.octopusden.octopus</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>@pom.version@</version>
         </plugin>


### PR DESCRIPTION
## Purpose

Temporary verification branch for [PR #17](https://github.com/octopusden/octopus-license-maven-plugin/pull/17) (Maven 3.6+ / Java 21+ refactor).

PR #17 currently runs only **2** invoker ITs (`jars-json-list-test-mojo`, `maven-api-compat`) via `pomIncludes`. This branch removes that restriction so the **full `src/it` suite (~59 projects)** runs against the PR #17 code.

## Changes vs PR #17

- **`pom.xml` `run-its` profile**
  - Remove `pomIncludes` filter → run all invoker projects
  - Enable `extraArtifacts` (needed by global-db ITs)
  - Exclude `MLICENSE-4` from main batch; run it in the offline execution
  - Exclude `download-licenses-basic` (live remote license URLs; same as upstream)
- **`compatibility.yml`**
  - Single matrix cell: **Java 8 / Maven 3.9.9** (full suite is slow; avoids 12 parallel heavy jobs)

## How to read results

- Green **Compatibility Matrix** → PR #17 refactor passes the full octopus IT suite on Java 8 + Maven 3.9.9
- Red → inspect invoker failure logs (`invoker.streamLogsOnFailures` enabled)

## Not for merge

This is a **verification PR only**. Do not merge into `octopus` as-is. If green, that gives confidence to merge PR #17; then follow up with permanent full-IT CI (see PR #18 approach on `main`).

## Test plan

- [ ] Wait for Compatibility Matrix workflow on this PR
- [ ] Review any failing IT names in the build log
- [ ] Close this draft PR after verification (or cherry-pick pom/workflow changes if we want full ITs permanently)


Made with [Cursor](https://cursor.com)